### PR TITLE
ioc: install user specified build and runtime packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ FROM ghcr.io/cnpem/lnls-debian-11-epics-7:${BUILD_STAGE_VERSION} AS BUILD_STAGE
 ARG JOBS=1
 ARG REPONAME
 ARG RUNDIR
+ARG BUILD_PACKAGES
 
 WORKDIR /opt/${REPONAME}
 
 COPY . .
 RUN echo STATIC_BUILD=YES >> configure/CONFIG_SITE.local && cp /opt/epics/RELEASE configure/RELEASE
+
+RUN if [ -n "$BUILD_PACKAGES" ]; then apt update && apt install $BUILD_PACKAGES; fi
 
 RUN make distclean && make -j ${JOBS} && make clean && make -C ${RUNDIR}
 
@@ -19,8 +22,9 @@ FROM debian:${DEBIAN_VERSION}-slim
 ARG REPONAME
 ARG RUNDIR
 ARG ENTRYPOINT=/bin/bash
+ARG RUNTIME_PACKAGES
 
-RUN apt update -y && apt install -y --no-install-recommends busybox netcat-openbsd procserv && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt update -y && apt install -y --no-install-recommends busybox netcat-openbsd procserv $RUNTIME_PACKAGES && apt clean && rm -rf /var/lib/apt/lists/*
 COPY --from=BUILD_STAGE /opt/${REPONAME} /opt/${REPONAME}
 
 WORKDIR ${RUNDIR}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ services:
         ENTRYPOINT: ./YOUR_ENTRYPOINT
 ```
 
+Additional build and runtime packages to be installed can be listed in `args`,
+under the `BUILD_PACKAGES` and `RUNTIME_PACKAGES` keys, respectively. It is not
+necessary to quote them - e.g. `BUILD_PACKAGES: python3 python3-requests`.
+Packages essential to all (or most) IOCs should be added to this repository's
+`Dockerfile`.
+
 The template above assumes the containers will be uploaded to the GitHub
 registry.
 


### PR DESCRIPTION
This is necessary for IOCs whose builds require additional tools, or for IOCs which require additional tools at runtime.

Since the build stage doesn't install any packages, we need to run "apt install" conditionally. For the final stage, we can simply add it to the existing install command. The variable expansion for both of the new variables isn't quoted, which is necessary to allow it to expand to a list of packages.

@mmdonatti 