### PR TITLE
Build epics-base with readline support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG RUNDIR
 ARG ENTRYPOINT=/bin/bash
 ARG RUNTIME_PACKAGES
 
-RUN apt update -y && apt install -y --no-install-recommends busybox netcat-openbsd procserv $RUNTIME_PACKAGES && apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt update -y && apt install -y --no-install-recommends libreadline8 busybox netcat-openbsd procserv $RUNTIME_PACKAGES && apt clean && rm -rf /var/lib/apt/lists/*
 COPY --from=BUILD_STAGE /opt/${REPONAME} /opt/${REPONAME}
 
 WORKDIR ${RUNDIR}

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt update -y && \
     apt install -y --no-install-recommends \
         build-essential \
+        libreadline-dev \
         re2c \
         wget \
         ca-certificates


### PR DESCRIPTION
This makes using iocsh much more practical, which is necessary when debugging applications. This means we have to install libreadline in the final container so the IOCs can be launched.