### PR TITLE
base: include libtiff in areaDetector build

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ registry.
 ### areaDetector IOCs
 
 `areaDetector` IOCs must be built with target `dynamic-link`. In addition, they
-must include `libxml2` in the `RUNTIME_PACKAGES`, as it is not built in
-`ADSupport`.
+must include `libxml2` and `libtiff5` in the `RUNTIME_PACKAGES`, as they are
+not built in `ADSupport`.
 
 ### Possible issues
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update -y && \
         git \
         libaravis-dev \
         libreadline-dev \
+        libtiff-dev \
         libusb-1.0-0-dev \
         libxml2-dev \
         re2c \

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -74,6 +74,11 @@ WITH_OPENCV=NO
 WITH_SZIP=YES
 SZIP_EXTERNAL=NO
 
+WITH_TIFF=YES
+TIFF_EXTERNAL=YES
+TIFF_LIB=$(pkg-config --variable=libdir libtiff-4)
+TIFF_INCLUDE=$(pkg-config --cflags-only-I libtiff-4 | sed -e "s|-I||g")
+
 XML2_EXTERNAL=YES
 XML2_LIB=$(pkg-config --variable=libdir libxml-2.0)
 XML2_INCLUDE=$(pkg-config --cflags-only-I libxml-2.0 | sed -e "s|-I||g")


### PR DESCRIPTION
I've included `libtiff` in the build so that we can use [`NDFileTIFF`](https://areadetector.github.io/master/ADCore/NDFileTIFF.html) plugin.

I've mistakenly left it off from #7.