### PR TITLE
Fix CI workflow for forked repositories

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Build image
         run: cd base && JOBS=$(nproc) docker compose build
       - name: Log in to registry
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Push tagged image
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'tag'
         run: docker push $REGISTRY/$IMAGE:$TAG
       - name: Push latest image
-        if: github.event_name == 'push' && github.ref_type == 'branch'
+        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'branch'
         run: |
           docker tag $REGISTRY/$IMAGE:$TAG $REGISTRY/$IMAGE:latest
           docker push $REGISTRY/$IMAGE:latest

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,7 +1,8 @@
 name: Base image build
 on:
   push:
-    tags-ignore:
+    tags:
+      - 'v*'
     branches:
       - main
 

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   TAG: ${{ github.event_name == 'push' && github.ref_name || github.head_ref }}
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE: lnls-debian-11-epics-7
+  SOURCE: https://github.com/${{ github.repository }}
 
 jobs:
   build_and_push:
@@ -26,7 +29,9 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Push tagged image
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        run: docker push ghcr.io/cnpem/lnls-debian-11-epics-7:$TAG
+        run: docker push $REGISTRY/$IMAGE:$TAG
       - name: Push latest image
         if: github.event_name == 'push' && github.ref_type == 'branch'
-        run: docker tag ghcr.io/cnpem/lnls-debian-11-epics-7:$TAG ghcr.io/cnpem/lnls-debian-11-epics-7:latest && docker push ghcr.io/cnpem/lnls-debian-11-epics-7:latest
+        run: |
+          docker tag $REGISTRY/$IMAGE:$TAG $REGISTRY/$IMAGE:latest
+          docker push $REGISTRY/$IMAGE:latest

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   epics-base:
-    image: ghcr.io/cnpem/lnls-debian-11-epics-7:$TAG
+    image: ${REGISTRY:-ghcr.io/cnpem}/lnls-debian-11-epics-7:$TAG
     build:
       context: ./
       dockerfile: Dockerfile
       labels:
         org.opencontainers.image.revision: ${TAG}
-        org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
+        org.opencontainers.image.source: ${SOURCE:-https://github.com/cnpem/epics-in-docker}
         org.opencontainers.image.description: "EPICS base and modules build image"
       args:
         JOBS: ${JOBS:-1}


### PR DESCRIPTION
I've changed the CI so that it works on forked repositories by using GItHub context variables. Although there are more build environment variables now, we can still build the image locally only defining the `TAG` (and `JOBS`) variables.

I've also fixed the issue of having tag pushes ignored. It works now. I've already tested in my fork. However, I'm not sure if you would like to keep with the idea of having any tag triggering the CI.