### PR TITLE
ioc: remove .git directory during build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /opt/${REPONAME}
 COPY . .
 
 RUN cp /opt/epics/RELEASE configure/RELEASE
+RUN rm -rf .git/
 
 
 FROM debian:${DEBIAN_VERSION}-slim as base


### PR DESCRIPTION
The .git directory for submodules isn't being removed by this command, but we will assume those are smaller, so not worth the effort to remove cleanly.