### PR TITLE
Install tarball packages with custom extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM debian:${DEBIAN_VERSION}-slim AS base
 ARG RUNDIR
 ARG ENTRYPOINT=/bin/bash
 ARG RUNTIME_PACKAGES
+ARG RUNTIME_TAR_PACKAGES
 
 RUN apt update -y && \
     apt install -y --no-install-recommends \
@@ -14,9 +15,14 @@ RUN apt update -y && \
         busybox \
         netcat-openbsd \
         procserv \
+        wget \
         $RUNTIME_PACKAGES && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-image /usr/local/bin/lnls-get-n-unpack /usr/local/bin/lnls-get-n-unpack
+RUN lnls-get-n-unpack -r $RUNTIME_TAR_PACKAGES && \
+    ldconfig
 
 WORKDIR ${RUNDIR}
 
@@ -34,8 +40,10 @@ FROM build-image AS build-stage
 
 ARG REPONAME
 ARG BUILD_PACKAGES
+ARG BUILD_TAR_PACKAGES
 
 RUN if [ -n "$BUILD_PACKAGES" ]; then apt update && apt install $BUILD_PACKAGES; fi
+RUN lnls-get-n-unpack -r $BUILD_TAR_PACKAGES
 
 WORKDIR /opt/${REPONAME}
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,6 +19,8 @@ RUN apt update -y && \
         wget \
         ca-certificates
 
+COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
+
 ARG EPICS_BASE_VERSION
 ENV EPICS_BASE_PATH /opt/epics/base
 ENV EPICS_MODULES_PATH /opt/epics/modules

--- a/base/install_epics.sh
+++ b/base/install_epics.sh
@@ -2,9 +2,7 @@
 
 set -ex
 
-wget https://epics-controls.org/download/base/base-${EPICS_BASE_VERSION}.tar.gz
-tar -xf base-${EPICS_BASE_VERSION}.tar.gz
-rm base-${EPICS_BASE_VERSION}.tar.gz
+lnls-get-n-unpack -l https://epics-controls.org/download/base/base-${EPICS_BASE_VERSION}.tar.gz
 
 mv base-${EPICS_BASE_VERSION} ${EPICS_BASE_PATH}
 make -j ${JOBS} -C ${EPICS_BASE_PATH} install

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -7,9 +7,7 @@ download_github_module() {
     module_name=$2
     tag=$3
 
-    wget https://github.com/$github_org/$module_name/archive/refs/tags/$tag.tar.gz
-    tar -xf $tag.tar.gz
-    rm $tag.tar.gz
+    lnls-get-n-unpack -l https://github.com/$github_org/$module_name/archive/refs/tags/$tag.tar.gz
 
     mv $module_name-$tag $module_name
 }
@@ -45,9 +43,7 @@ install_github_module() {
 echo EPICS_BASE=${EPICS_BASE_PATH} > ${EPICS_MODULES_PATH}/../RELEASE
 
 # Build seq first since it doesn't depend on anything
-wget "https://static.erico.dev/seq-$SEQUENCER_VERSION.tar.gz"
-tar -xf seq-$SEQUENCER_VERSION.tar.gz
-rm seq-$SEQUENCER_VERSION.tar.gz
+lnls-get-n-unpack -l "https://static.erico.dev/seq-$SEQUENCER_VERSION.tar.gz"
 mv seq-$SEQUENCER_VERSION seq
 install_module seq SNCSEQ "
 EPICS_BASE = ${EPICS_BASE_PATH}

--- a/base/lnls-get-n-unpack.sh
+++ b/base/lnls-get-n-unpack.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Download and extract tarball archive from the network.
+
+set -eu
+
+case "$1" in
+    -r) dest=/ ;;
+    -l) dest=. ;;
+    *) >&2 echo "Invalid extraction mode: must be either root (-r) or local (-l)."
+       exit 1;
+    ;;
+esac
+
+shift
+
+for url; do
+    download_dir=$(mktemp -d)
+
+    echo Downloading "$url"...
+    wget -P $download_dir -o /tmp/wget.log "$url" || (cat /tmp/wget.log && false)
+    tar --no-same-owner -xf $download_dir/* -C $dest
+    rm -rf $download_dir /tmp/wget.log
+done


### PR DESCRIPTION
Installing through tarballs is useful to enable us to include software that is not yet packaged in the distribution repositories.

A custom extraction script is interesting to solve, in a centralized way, permission issues in rootless container engines both for source code and binaries packages.

I've named the custom script `untar`, but I'm open to suggestions for other names.