### PR TITLE
ioc: use non-interactive install for build-stage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ ARG REPONAME
 ARG BUILD_PACKAGES
 ARG BUILD_TAR_PACKAGES
 
-RUN if [ -n "$BUILD_PACKAGES" ]; then apt update && apt install $BUILD_PACKAGES; fi
+RUN if [ -n "$BUILD_PACKAGES" ]; then \
+        apt update && \
+        apt install -y --no-install-recommends $BUILD_PACKAGES; \
+    fi
 RUN lnls-get-n-unpack -r $BUILD_TAR_PACKAGES
 
 WORKDIR /opt/${REPONAME}


### PR DESCRIPTION
This is required to use `BUILD_PACKAGES` to install any package. No recommended package option has also been enabled to avoid unused packages in the resulting IOC image. Lines have been broken to make it easier to read and maintain this step.