### PR TITLE
ioc: add script to launch IOCs inside container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/cnpem/lnls-debian-11-epics-7:v0.3.0 AS build-image
 FROM debian:${DEBIAN_VERSION}-slim AS base
 
 ARG RUNDIR
-ARG ENTRYPOINT=/bin/bash
+ARG ENTRYPOINT=/usr/local/bin/lnls-run
 ARG RUNTIME_PACKAGES
 ARG RUNTIME_TAR_PACKAGES
 
@@ -23,6 +23,8 @@ RUN apt update -y && \
 COPY --from=build-image /usr/local/bin/lnls-get-n-unpack /usr/local/bin/lnls-get-n-unpack
 RUN lnls-get-n-unpack -r $RUNTIME_TAR_PACKAGES && \
     ldconfig
+
+COPY --from=build-image /usr/local/bin/lnls-run /usr/local/bin/lnls-run
 
 WORKDIR ${RUNDIR}
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ you **need** to link them dynamically, you must define the build target as
 `dynamic-link`. This will increase the resulting image size, since unused
 dependencies will also be copied.
 
+The resulting image contains a standard IOC run script, `lnls-run`, which will
+be run inside `RUNDIR` and will launch the container's command under procServ,
+or `st.cmd` if no command is specified.
+
 Some Docker versions don't use
 [BuildKit](https://docs.docker.com/build/buildkit/) by default, and it can be
 more efficient to enable it, for instance, by exporting `DOCKER_BUILDKIT=1`
@@ -70,3 +74,16 @@ not built in `ADSupport`.
 
 Known build and runtime issues are documented in the [SwC
 wiki](http://swc.lnls.br/).
+
+## Containers
+
+### Accessing `iocsh` inside containers
+
+If a container is using the default `lnls-run` entrypoint (i.e. this won't work
+for containers launched by the `iocs` script for SIRIUS beamlines), its IOC's
+`iocsh` can be accessed with the following command (use `podman` if
+appropriate):
+
+```
+$ docker exec -ti <container> nc -U ioc.sock
+```

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ stages even when they are not needed.
 Additional build and runtime packages to be installed can be listed in `args`,
 under the `BUILD_PACKAGES` and `RUNTIME_PACKAGES` keys, respectively. It is not
 necessary to quote them - e.g. `BUILD_PACKAGES: python3 python3-requests`.
-Packages essential to all (or most) IOCs should be added to this repository's
-`Dockerfile`.
+Packages essential to all (or most) IOCs should be added to [this repository's
+`Dockerfile`](./Dockerfile).
 
 The template above assumes the containers will be uploaded to the GitHub
 registry.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,6 +20,7 @@ RUN apt update -y && \
         ca-certificates
 
 COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
+COPY lnls-run.sh /usr/local/bin/lnls-run
 
 ARG EPICS_BASE_VERSION
 ENV EPICS_BASE_PATH /opt/epics/base

--- a/base/lnls-run.sh
+++ b/base/lnls-run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then set ./st.cmd; fi
+exec procServ -f -i ^C^D -L - unix:./ioc.sock "$@"


### PR DESCRIPTION
Setting this script as the default entrypoint for our containers allows IOCs which use "st.cmd" as their startup script to be launched without specifying any command in the command line or YAML orchestrator file, and still support other startup scripts or shell wrappers that perform the necessary setup before launching the IOC, but not having to call procServ themselves.

Furthermore, it means that there is a default location for the procServ socket, which can be documented.