### PR TITLE
base: extract install functions to shared file.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,6 +26,8 @@ ENV EPICS_BASE_PATH /opt/epics/base
 ENV EPICS_MODULES_PATH /opt/epics/modules
 
 WORKDIR /opt/epics
+COPY install-functions.sh .
+
 COPY install_epics.sh .
 RUN ./install_epics.sh
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -24,6 +24,7 @@ COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
 ARG EPICS_BASE_VERSION
 ENV EPICS_BASE_PATH /opt/epics/base
 ENV EPICS_MODULES_PATH /opt/epics/modules
+ENV EPICS_RELEASE_FILE /opt/epics/RELEASE
 
 WORKDIR /opt/epics
 COPY install-functions.sh .

--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -19,9 +19,9 @@ install_module() {
     make -j${JOBS} install
     make clean
 
-    cd -
+    echo ${dependency_name}=${PWD} >> ${EPICS_MODULES_PATH}/../RELEASE
 
-    echo ${dependency_name}=${EPICS_MODULES_PATH}/${module_name} >> ${EPICS_MODULES_PATH}/../RELEASE
+    cd -
 }
 
 # Install module from GitHub tagged versions or URL

--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -1,0 +1,37 @@
+download_github_module() {
+    github_org=$1
+    module_name=$2
+    tag=$3
+
+    lnls-get-n-unpack -l https://github.com/$github_org/$module_name/archive/refs/tags/$tag.tar.gz
+
+    mv $module_name-$tag $module_name
+}
+
+install_module() {
+    module_name=$1
+    dependency_name=$2
+    release_content="$3"
+
+    cd $module_name
+    echo "$release_content" > configure/RELEASE
+
+    make -j${JOBS} install
+    make clean
+
+    cd -
+
+    echo ${dependency_name}=${EPICS_MODULES_PATH}/${module_name} >> ${EPICS_MODULES_PATH}/../RELEASE
+}
+
+# Install module from GitHub tagged versions or URL
+install_github_module() {
+    github_org=$1
+    module_name=$2
+    dependency_name=$3
+    tag=$4
+    release_content="$5"
+
+    download_github_module $github_org $module_name $tag
+    install_module $module_name $dependency_name "$release_content"
+}

--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -19,7 +19,7 @@ install_module() {
     make -j${JOBS} install
     make clean
 
-    echo ${dependency_name}=${PWD} >> ${EPICS_MODULES_PATH}/../RELEASE
+    echo ${dependency_name}=${PWD} >> ${EPICS_RELEASE_FILE}
 
     cd -
 }

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -25,7 +25,7 @@ ADSUPPORT=${EPICS_MODULES_PATH}/areaDetector/ADSupport
 ADCORE=${EPICS_MODULES_PATH}/areaDetector/ADCore
 "
 
-echo "$module_releases" >> ${EPICS_MODULES_PATH}/../RELEASE
+echo "$module_releases" >> ${EPICS_RELEASE_FILE}
 
 echo "
 EPICS_BASE=${EPICS_BASE_PATH}

--- a/base/install_epics.sh
+++ b/base/install_epics.sh
@@ -2,8 +2,9 @@
 
 set -ex
 
-lnls-get-n-unpack -l https://epics-controls.org/download/base/base-${EPICS_BASE_VERSION}.tar.gz
+. /opt/epics/install-functions.sh
 
+lnls-get-n-unpack -l https://epics-controls.org/download/base/base-${EPICS_BASE_VERSION}.tar.gz
 mv base-${EPICS_BASE_VERSION} ${EPICS_BASE_PATH}
-make -j ${JOBS} -C ${EPICS_BASE_PATH} install
-make -C ${EPICS_BASE_PATH} clean
+
+install_module base EPICS_BASE

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -2,43 +2,7 @@
 
 set -ex
 
-download_github_module() {
-    github_org=$1
-    module_name=$2
-    tag=$3
-
-    lnls-get-n-unpack -l https://github.com/$github_org/$module_name/archive/refs/tags/$tag.tar.gz
-
-    mv $module_name-$tag $module_name
-}
-
-install_module() {
-    module_name=$1
-    dependency_name=$2
-    release_content="$3"
-
-    cd $module_name
-    echo "$release_content" > configure/RELEASE
-
-    make -j${JOBS} install
-    make clean
-
-    cd -
-
-    echo ${dependency_name}=${EPICS_MODULES_PATH}/${module_name} >> ${EPICS_MODULES_PATH}/../RELEASE
-}
-
-# Install module from GitHub tagged versions or URL
-install_github_module() {
-    github_org=$1
-    module_name=$2
-    dependency_name=$3
-    tag=$4
-    release_content="$5"
-
-    download_github_module $github_org $module_name $tag
-    install_module $module_name $dependency_name "$release_content"
-}
+. /opt/epics/install-functions.sh
 
 echo EPICS_BASE=${EPICS_BASE_PATH} > ${EPICS_MODULES_PATH}/../RELEASE
 

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -4,8 +4,6 @@ set -ex
 
 . /opt/epics/install-functions.sh
 
-echo EPICS_BASE=${EPICS_BASE_PATH} > ${EPICS_MODULES_PATH}/../RELEASE
-
 # Build seq first since it doesn't depend on anything
 lnls-get-n-unpack -l "https://static.erico.dev/seq-$SEQUENCER_VERSION.tar.gz"
 mv seq-$SEQUENCER_VERSION seq

--- a/base/install_motor.sh
+++ b/base/install_motor.sh
@@ -14,7 +14,7 @@ module_releases="
 MOTOR=${EPICS_MODULES_PATH}/motor
 MOTOR_MOTORSIM=${EPICS_MODULES_PATH}/motor/modules/motorMotorSim
 "
-echo "$module_releases" >> ${EPICS_MODULES_PATH}/../RELEASE
+echo "$module_releases" >> ${EPICS_RELEASE_FILE}
 
 cd ../configure
 


### PR DESCRIPTION
These installation functions can be used in other scripts. This simplifies their logic through reuse and centralizes standardization. I've also refactored `install_epics.sh` to use it already.

The name of the script is something I'm open to suggestions. I'm okay with the name, but I'm sure there is a better one that I couldn't know of. :)