### PR TITLE
Separate pimega build from area_detector.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,7 +26,7 @@ COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
 ARG LIBPIMEGA_VERSION
 
 RUN lnls-get-n-unpack -r \
-    http://gca-jobs:1234/packages/libpimega_${LIBPIMEGA_VERSION}_amd64.tar.gz
+            http://10.30.1.74/packages/libpimega_${LIBPIMEGA_VERSION}_amd64.tar.gz
 
 ARG EPICS_BASE_VERSION
 ENV EPICS_BASE_PATH /opt/epics/base
@@ -62,6 +62,9 @@ RUN ./install_modules.sh
 COPY nanohttp_stream.patch .
 COPY install_area_detector.sh .
 RUN ./install_area_detector.sh
+
+COPY install_pimega.sh .
+RUN ./install_pimega.sh
 
 COPY install_motor.sh .
 RUN ./install_motor.sh

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -99,32 +99,3 @@ git apply --directory ADSupport ${EPICS_MODULES_PATH}/nanohttp_stream.patch
 make -j${JOBS}
 make clean
 
-cd ..
-
-git clone --depth 1 --branch ${LIBSSCPIMEGA_VERSION} \
-    https://github.com/cnpem/ssc-pimega
-
-make -C ssc-pimega/c install
-
-install_github_module cnpem NDSSCPimega NDSSCPIMEGA $NDSSCPIMEGA_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-ASYN=${EPICS_MODULES_PATH}/asyn
-AREA_DETECTOR=${EPICS_MODULES_PATH}/areaDetector
-ADCORE=${EPICS_MODULES_PATH}/areaDetector/ADCore
-"
-
-cd areaDetector
-
-lnls-get-n-unpack -l http://gca-jobs:1234/packages/ad-pimega_${ADPIMEGA_VERSION}.tar.gz
-
-echo "
-EPICS_BASE=${EPICS_BASE_PATH}
-" > ADPimega/configure/RELEASE.local
-
-echo "ADPIMEGA=${EPICS_MODULES_PATH}/areaDetector/ADPimega" >> $EPICS_RELEASE_FILE
-
-echo "BUILD_IOCS=YES" >> configure/CONFIG_SITE
-cp $EPICS_RELEASE_FILE ADPimega/iocs/pimegaIOC/configure/RELEASE
-
-make -C ADPimega

--- a/base/install_pimega.sh
+++ b/base/install_pimega.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -ex
+
+. /opt/epics/install-functions.sh
+
+cd /opt/epics/modules
+
+git clone --depth 1 --branch ${LIBSSCPIMEGA_VERSION} \
+    https://github.com/cnpem/ssc-pimega
+
+make -C ssc-pimega/c install
+
+install_github_module cnpem NDSSCPimega NDSSCPIMEGA $NDSSCPIMEGA_VERSION "
+EPICS_BASE = ${EPICS_BASE_PATH}
+
+ASYN=${EPICS_MODULES_PATH}/asyn
+AREA_DETECTOR=${EPICS_MODULES_PATH}/areaDetector
+ADCORE=${EPICS_MODULES_PATH}/areaDetector/ADCore
+"
+
+cd areaDetector
+
+lnls-get-n-unpack -l http://10.30.1.74/packages/ad-pimega_${ADPIMEGA_VERSION}.tar.gz
+
+echo "
+EPICS_BASE=${EPICS_BASE_PATH}
+" > ADPimega/configure/RELEASE.local
+
+echo "ADPIMEGA=${EPICS_MODULES_PATH}/areaDetector/ADPimega" >> $EPICS_RELEASE_FILE
+
+echo "BUILD_IOCS=YES" >> configure/CONFIG_SITE
+cp $EPICS_RELEASE_FILE ADPimega/iocs/pimegaIOC/configure/RELEASE
+
+make -C ADPimega


### PR DESCRIPTION
Pimega build is something that we will probably do frequently here and throwing away the areadetector build cache to rebuild pimega is time consuming.

Maybe this could be done for all modules? Particularly for me, pimega is enough, but standardization is never bad.