### PR TITLE
Post-release development version bump.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DEBIAN_VERSION=11.7
 
-FROM ghcr.io/cnpem/lnls-debian-11-epics-7:v0.4.0 AS build-image
+FROM ghcr.io/cnpem/lnls-debian-11-epics-7:v0.4.0-dev AS build-image
 
 FROM debian:${DEBIAN_VERSION}-slim AS base
 


### PR DESCRIPTION
This has been missing from the latest release (v0.4.0), and I don't have the rights to push directly to the main branch.