### PR TITLE
base: build epics-base with GCC_PIPE=YES.

### DIFF
--- a/base/install_epics.sh
+++ b/base/install_epics.sh
@@ -7,6 +7,8 @@ set -ex
 lnls-get-n-unpack -l https://epics-controls.org/download/base/base-${EPICS_BASE_VERSION}.tar.gz
 mv base-${EPICS_BASE_VERSION} ${EPICS_BASE_PATH}
 
+echo GCC_PIPE=YES >> ${EPICS_BASE_PATH}/configure/CONFIG_SITE
+
 patch -d ${EPICS_BASE_PATH} -Np1 < backport-epics-base-musl.patch
 
 install_module base EPICS_BASE


### PR DESCRIPTION
This can speed up the build by avoiding usage of temporary files.