### PR TITLE
ci: use docker/bake-action.

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -25,17 +25,21 @@ jobs:
       IMAGE: ${{ matrix.image.name }}
       SOURCE: https://github.com/${{ github.repository }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Build image
-        run: cd ${{ matrix.image.dir }} && JOBS=$(nproc) docker compose build
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - name: Log in to registry
         if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-      - name: Push tagged image
-        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'tag'
-        run: docker push $REGISTRY/$IMAGE:$TAG
-      - name: Push latest image
-        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'branch'
-        run: |
-          docker tag $REGISTRY/$IMAGE:$TAG $REGISTRY/$IMAGE:latest
-          docker push $REGISTRY/$IMAGE:latest
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push tagged image
+        uses: docker/bake-action@v4
+        with:
+          workdir: ${{ matrix.image.dir }}
+          files: docker-compose.yml
+          set: |
+            *.cache-from=type=gha,scope=${{ matrix.image.name }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.image.name }}
+          push: ${{ github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'tag' }}


### PR DESCRIPTION
This allows us to avoid writing our own commands for things, and works with GHA cache for images, which speeds up CI and avoids unnecessary resource usage.