### PR TITLE
base: disable bash tracing from install scripts.

### DIFF
--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 . /opt/epics/install-functions.sh
 

--- a/base/install_epics.sh
+++ b/base/install_epics.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 
 . /opt/epics/install-functions.sh
 

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 . /opt/epics/install-functions.sh
 

--- a/base/install_motor.sh
+++ b/base/install_motor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 . /opt/epics/install-functions.sh
 


### PR DESCRIPTION
This level of detail pollutes the output during the build, while often not being used. In addition, it can be easily turned back on in a local setup for debugging purposes.

It should not influence any output seen by epics-in-docker users, so no entry is specified in the changelog.