### PR TITLE
base: use RELEASE to determine module paths.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 * base: update modules. by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/43
   * This updates the autosave module and removes some resource leaks.
+* base: build CALC with Sequencer support. by @henriquesimoes in
+  https://github.com/cnpem/epics-in-docker/pull/48
 
 ## v0.6.0
 

--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -1,3 +1,11 @@
+get_module_path() {
+    for module in $@; do
+        if [ -n "$module" ]; then
+            grep -E "^$module=" $EPICS_RELEASE_FILE
+        fi
+    done
+}
+
 download_github_module() {
     github_org=$1
     module_name=$2
@@ -11,10 +19,11 @@ download_github_module() {
 install_module() {
     module_name=$1
     dependency_name=$2
-    release_content="$3"
+    release_modules="$3"
 
     cd $module_name
-    echo "$release_content" > configure/RELEASE
+    get_module_path "$release_modules" > configure/RELEASE
+
     if [ -n "$NEEDS_TIRPC" ]; then
         echo "TIRPC=YES" >> configure/CONFIG_SITE
     fi

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -29,15 +29,13 @@ ADCORE=${EPICS_MODULES_PATH}/areaDetector/ADCore
 
 echo "$module_releases" >> ${EPICS_RELEASE_FILE}
 
-echo "
-EPICS_BASE=${EPICS_BASE_PATH}
-
-$module_releases
-
-ASYN=${EPICS_MODULES_PATH}/asyn
-BUSY=${EPICS_MODULES_PATH}/busy
-SSCAN=${EPICS_MODULES_PATH}/sscan
+get_module_path "
+EPICS_BASE
+ASYN
+BUSY
+SSCAN
 " > RELEASE.local
+echo "$module_releases" >> RELEASE.local
 
 ln -s RELEASE.local RELEASE_PRODS.local
 ln -s RELEASE.local RELEASE_LIBS.local
@@ -105,9 +103,8 @@ download_github_module cnpem ssc-pimega $LIBSSCPIMEGA_VERSION
 make -C ssc-pimega/c install
 
 install_github_module cnpem NDSSCPimega NDSSCPIMEGA $NDSSCPIMEGA_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-ASYN=${EPICS_MODULES_PATH}/asyn
-AREA_DETECTOR=${EPICS_MODULES_PATH}/areaDetector
-ADCORE=${EPICS_MODULES_PATH}/areaDetector/ADCore
+EPICS_BASE
+ASYN
+AREA_DETECTOR
+ADCORE
 "

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -5,65 +5,60 @@ set -ex
 . /opt/epics/install-functions.sh
 
 install_github_module mdavidsaver pvxs PVXS $PVXS_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 # Build seq first since it doesn't depend on anything
 lnls-get-n-unpack -l "https://static.erico.dev/seq-$SEQUENCER_VERSION.tar.gz"
 mv seq-$SEQUENCER_VERSION seq
 install_module seq SNCSEQ "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 install_github_module epics-modules calc CALC $CALC_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-SNCSEQ = ${EPICS_MODULES_PATH}/seq
+EPICS_BASE
+SNCSEQ
 "
 
 # Build asyn without seq since it's only needed for testIPServer
 install_github_module epics-modules asyn ASYN $ASYN_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-CALC = ${EPICS_MODULES_PATH}/calc
+EPICS_BASE
+CALC
 "
 
 install_github_module paulscherrerinstitute StreamDevice STREAM $STREAMDEVICE_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-ASYN = ${EPICS_MODULES_PATH}/asyn
-CALC = ${EPICS_MODULES_PATH}/calc
+EPICS_BASE
+ASYN
+CALC
 "
 
 install_github_module epics-modules busy BUSY $BUSY_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-ASYN = ${EPICS_MODULES_PATH}/asyn
+EPICS_BASE
+ASYN
 "
 
 install_github_module epics-modules autosave AUTOSAVE $AUTOSAVE_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 install_github_module epics-modules sscan SSCAN $SSCAN_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
-
-SNCSEQ = ${EPICS_MODULES_PATH}/seq
+EPICS_BASE
+SNCSEQ
 "
 
 download_github_module ChannelFinder recsync $RECCASTER_VERSION
 install_module recsync/client RECCASTER "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 install_github_module epics-modules ipac IPAC $IPAC_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 install_github_module epics-modules caPutLog CAPUTLOG $CAPUTLOG_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "
 
 install_github_module brunoseivam retools RETOOLS $RETOOLS_VERSION "
-EPICS_BASE = ${EPICS_BASE_PATH}
+EPICS_BASE
 "

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -18,7 +18,7 @@ EPICS_BASE = ${EPICS_BASE_PATH}
 install_github_module epics-modules calc CALC $CALC_VERSION "
 EPICS_BASE = ${EPICS_BASE_PATH}
 
-SEQ = ${EPICS_MODULES_PATH}/seq
+SNCSEQ = ${EPICS_MODULES_PATH}/seq
 "
 
 # Build asyn without seq since it's only needed for testIPServer

--- a/base/install_motor.sh
+++ b/base/install_motor.sh
@@ -20,12 +20,12 @@ echo "$module_releases" >> ${EPICS_RELEASE_FILE}
 
 cd ../configure
 
-echo "
-EPICS_BASE=${EPICS_BASE_PATH}
-ASYN=${EPICS_MODULES_PATH}/asyn
-SNCSEQ=${EPICS_MODULES_PATH}/seq
-BUSY=${EPICS_MODULES_PATH}/busy
-IPAC=${EPICS_MODULES_PATH}/ipac
+get_module_path "
+EPICS_BASE
+ASYN
+SNCSEQ
+BUSY
+IPAC
 " > RELEASE.local
 
 echo "
@@ -57,9 +57,9 @@ WITH_BOOST = NO
 " >> pmac/configure/CONFIG_SITE
 
 JOBS=1 install_module pmac PMAC "
-EPICS_BASE=${EPICS_BASE_PATH}
-ASYN=${EPICS_MODULES_PATH}/asyn
-CALC=${EPICS_MODULES_PATH}/calc
-MOTOR=${EPICS_MODULES_PATH}/motor
-BUSY=${EPICS_MODULES_PATH}/busy
+EPICS_BASE
+ASYN
+CALC
+MOTOR
+BUSY
 "


### PR DESCRIPTION
Right after being installed, a module adds its own path to the RELEASE file. Use this as the source of truth for specifying the dependencies' path in later module builds. Since a module cannot be built without its dependency already built, this does not limit our installation scripts.

This removes duplication of several paths of modules, which may now change more easily.