### PR TITLE
README: fix GitHub Actions job definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    uses: cnpem/epics-in-docker/.github/workflows/ioc-images.yml
+    uses: cnpem/epics-in-docker/.github/workflows/ioc-images.yml@main
 ```
 
 ## Containers


### PR DESCRIPTION
The version in a "uses" key is mandatory.

Fixes: 7b01e955aa7bd2732bb8ef53c24efad9d6347aaa