### PR TITLE
ci: use valid tag name for pull request events.

### DIFF
--- a/.github/workflows/ioc-images.yml
+++ b/.github/workflows/ioc-images.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       REGISTRY: ghcr.io/${{ github.repository_owner }}
       SOURCE: https://github.com/${{ github.repository }}
-      TAG: ${{ github.ref_name }}
+      TAG: ${{ github.event_name == 'push' && github.ref_name || github.head_ref }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GitHub context variable `ref_name` has an invalid pattern (`<pr>/merge`) for container image tags when events are generated by pull requests. In such cases, `head_ref` should be used in the IOC build workflow instead.

Fixes: 4cd3893 ("ci: add reusable job for IOC images.")