### PR TITLE
ioc: copy locally installed software from build stages.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
   https://github.com/cnpem/epics-in-docker/pull/42
 * ci: add reusable job for IOC images. by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/49
+* ioc: copy locally installed software from build stages. by @henriquesimoes in
+  https://github.com/cnpem/epics-in-docker/pull/55
+  * This allows the IOC build phase to install custom files, available at
+    runtime, under `/usr/local` tree for all targets.
 
 ### Bug fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENTRYPOINT ["./entrypoint"]
 FROM base AS no-build
 
 COPY --from=build-image /opt /opt
+COPY --from=build-image /usr/local /usr/local
 
 
 FROM build-image AS build-stage
@@ -70,6 +71,7 @@ RUN make distclean && make -j ${JOBS} && make clean && make -C ${RUNDIR}
 FROM base AS dynamic-link
 
 COPY --from=dynamic-build /opt /opt
+COPY --from=dynamic-build /usr/local /usr/local
 
 
 FROM build-stage AS static-build
@@ -87,3 +89,4 @@ FROM base AS static-link
 ARG REPONAME
 
 COPY --from=static-build /opt/${REPONAME} /opt/${REPONAME}
+COPY --from=static-build /usr/local /usr/local


### PR DESCRIPTION
Software, other than shared libraries, may be built in the first stages, but are currently not available in the resulting IOC image. Copy the entire `/usr/local` tree in all IOC stages, so that locally installed binaries and configuration can be usable at runtime.

This allows us to build custom versions of applications during build phases and install them at IOC images, centralizing and making it easier to track how they are built. In addition, IOCs can also install custom files which will be available at runtime in a known location. Still, IOCs themselves can also be installed in [FHS-compliant paths][1] inside the container as any other packaged software, allowing them to make use of tools based on system-installed artifacts (such as `env` executable discovery).

[1]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html