### PR TITLE
Prune unused artifacts from non-static builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@
 * base: update to Debian 12. by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/84
   * Refer to up to date README for new/updated `RUNTIME_PACKAGES`.
+* Prune unused artifacts from non-static builds by @henriquesimoes in
+  https://github.com/cnpem/epics-in-docker/pull/59
+  * Pruning will happen automatically, and most cases shouldn't require any
+    configuration. Refer to the README for instructions on how to configure the
+    procedure when needed.
 
 ## v0.12.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,9 @@ FROM build-image AS pruned-build
 
 ARG APP_DIRS
 ARG RUNDIR
+ARG SKIP_PRUNE
 
-RUN lnls-prune-artifacts ${APP_DIRS} ${RUNDIR}
+RUN if [ "$SKIP_PRUNE" != 1 ]; then lnls-prune-artifacts ${APP_DIRS} ${RUNDIR}; fi
 
 
 FROM base AS no-build
@@ -81,10 +82,11 @@ ARG JOBS=1
 ARG APP_DIRS
 ARG RUNDIR
 ARG SKIP_TESTS
+ARG SKIP_PRUNE
 
 RUN make distclean && make -j ${JOBS} && make $([ "$SKIP_TESTS" != 1 ] && echo runtests) && make clean && make -C ${RUNDIR}
 
-RUN lnls-prune-artifacts ${APP_DIRS} ${PWD} ${RUNDIR}
+RUN if [ "$SKIP_PRUNE" != 1 ]; then lnls-prune-artifacts ${APP_DIRS} ${PWD} ${RUNDIR}; fi
 
 
 FROM base AS dynamic-link

--- a/README.md
+++ b/README.md
@@ -51,8 +51,24 @@ services:
 
 By default, the IOC will be built with statically linked EPICS libraries. If
 you **need** to link them dynamically, you must define the build target as
-`dynamic-link`. This will increase the resulting image size, since unused
-dependencies will also be copied.
+`dynamic-link`.
+
+For non-static builds, an automatic pruning step is executed to make the IOC
+image size smaller by removing unused artifacts. This step preserves all ELF
+executables inside `RUNDIR` and the IOC repository, as well as their dependent
+EPICS modules based on the linkage information. Source code, GUI files, and
+other directories in used modules are assumed not to be needed at runtime and
+also removed. Additional paths can be provided in `args` under the `APP_DIRS`
+key to extend the list of where used applications and shared libraries are,
+including any `dlopen(3)`ed libraries. If the resulting image fails at runtime,
+a careful look at error messages might provide clues for directories to add to
+`APP_DIRS`; if that isn't possible, or if it's believed that the directories
+added to `APP_DIRS` should have been detected automatically, please open an
+issue. Please do so as well if the pruning step errors out during the build. In
+case it is necessary to build a working image before these issues can be fixed,
+the pruning step can be skipped entirely by setting the `SKIP_PRUNE=1`
+argument; note that this is highly discouraged, because it increases the image
+size significantly.
 
 The resulting image contains a standard IOC run script, `lnls-run`, which will
 be run inside `RUNDIR` and will launch the container's command under procServ,

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,7 +35,6 @@ RUN apt update -y && \
         ca-certificates
 
 COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
-COPY lnls-run.sh /usr/local/bin/lnls-run
 
 ENV EPICS_IN_DOCKER=/opt/epics-in-docker
 RUN mkdir $EPICS_IN_DOCKER
@@ -68,3 +67,5 @@ RUN $EPICS_IN_DOCKER/install_motor.sh
 ARG DEBIAN_VERSION
 COPY opcua_versions.sh install_opcua.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_opcua.sh
+
+COPY lnls-run.sh /usr/local/bin/lnls-run

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -68,4 +68,5 @@ ARG DEBIAN_VERSION
 COPY opcua_versions.sh install_opcua.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_opcua.sh
 
+COPY lnls-prune-artifacts.sh /usr/local/bin/lnls-prune-artifacts
 COPY lnls-run.sh /usr/local/bin/lnls-run

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -19,6 +19,8 @@ git submodule update --init --depth 1 -j ${JOBS} \
 
 rm -rf .git
 
+echo 'ADSupport/lib/linux*/libHDF5*plugin.so' > .lnls-keep-paths
+
 cd configure
 
 module_releases="

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -96,6 +96,7 @@ echo PYTHON=python3 >> pyDevSup/configure/CONFIG_SITE
 install_module pyDevSup PYDEVSUP "
 EPICS_BASE
 "
+echo 'python3*/linux*/' > pyDevSup/.lnls-keep-paths
 
 mkdir snmp
 cd snmp

--- a/base/lnls-prune-artifacts.sh
+++ b/base/lnls-prune-artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -Eeu
+
+# Filter out from the $1 list of paths any exact match of a parent directory
+# from any path in the $2 exclude list.
+#
+# Both lists are treated as newline-separated strings, and must consist
+# exclusively of absolute paths (except for empty lines which are ignored).
+filter_out_paths() {
+    list=$(echo "$1" | grep -v '^$')
+    exclude_list=$(echo "$2" | grep -v '^$')
+
+    while read -r path; do
+        if [ "${path:0:1}" != "/" ]; then
+            >&2 echo "error: filter_out_paths() expects absolute paths, but got '$path'"
+            exit 1
+        fi
+
+        while [ "$path" != "/" ]; do
+            list=$(echo "$list" | grep -xv "$path")
+
+            path=$(dirname "$path")
+        done
+    done <<< "$exclude_list"
+
+    echo "$list"
+}
+
+# Output the set $1 difference to another set $2
+compute_set_difference() {
+    sort $1 $2 $2 | uniq -u
+}
+
+find_elf_executables() {
+    targets=$@
+
+    # Loop on entire lines to properly handle filenames with spaces
+    while read -r file; do
+        read -r -N 4 magic < "$file"
+
+        # Output only ELF binaries
+        if [ "$magic" = $'\x7fELF' ]; then
+            echo $file
+        fi
+    done < <(find $targets -type f)
+}
+
+find_linked_libraries() {
+    executables=$(find_elf_executables $@)
+
+    # Depend on the glibc-specific behavior of supporting multiple executables
+    # to be queried at once
+    linked=$(ldd $executables 2>/dev/null | grep '=>')
+
+    # We grep out not found libraries, since they cannot be kept if we don't
+    # know where they are.
+    #
+    # Final binary may be actually runnable, since rpath of another binary may
+    # pull those not-found libraries
+    found="$(echo "$linked" | grep -v "not found")"
+
+    # Get their full path
+    libs=$(echo "$found" | cut -d' ' -f 3)
+
+    echo "$libs" | sort -u
+}
+
+get_all_epics_modules() {
+    release_defs=$(grep = ${EPICS_RELEASE_FILE} | cut -d'=' -f 2)
+
+    echo "$release_defs" | grep $EPICS_MODULES_PATH
+}
+
+get_used_epics_modules() {
+    linked_libs=$(find_linked_libraries $@)
+    all_modules=$(get_all_epics_modules)
+
+    unused_modules=$(filter_out_paths "$all_modules" "$linked_libs")
+
+    compute_set_difference <(echo "$all_modules") <(echo "$unused_modules")
+}
+
+remove_unused_epics_modules() {
+    targets=$(echo $@ | sed -E "s|\s+|\n|g")
+
+    all_modules=$(get_all_epics_modules)
+    used_modules=$(get_used_epics_modules $targets)
+    cat << EOF
+===
+Used EPICS modules
+===
+$used_modules
+===
+EOF
+
+    keep_paths=$(printf "$targets\n$used_modules")
+    unused_modules=$(filter_out_paths "$all_modules" "$keep_paths")
+
+    # Assume module paths do not contain spaces, as we mostly control them
+    for module in $unused_modules; do
+        # if we already removed it because of its top-level repository or
+        # because it is an IOC, move on to the next.
+        [ ! -d $module ] && continue
+
+        size=$(du -hs $module | cut -f 1)
+
+        echo "Removing module '$module' ($size)..."
+        rm -rf $module
+    done
+}
+
+remove_unused_epics_modules $@

--- a/base/lnls-prune-artifacts.sh
+++ b/base/lnls-prune-artifacts.sh
@@ -110,4 +110,18 @@ EOF
     done
 }
 
+remove_static_libraries() {
+    for target; do
+        libs=$(find $target -type f -name *.a)
+
+        if [ -n "$libs" ]; then
+            size=$(du -hsc $libs | tail -n 1 | cut -f 1)
+
+            echo "Removing static libraries from $target ($size)"
+            rm -f $libs
+        fi
+    done
+}
+
 remove_unused_epics_modules $@
+remove_static_libraries /opt /usr/local

--- a/base/lnls-prune-artifacts.sh
+++ b/base/lnls-prune-artifacts.sh
@@ -76,6 +76,8 @@ get_all_epics_modules() {
     release_defs=$(grep = ${EPICS_RELEASE_FILE} | cut -d'=' -f 2)
 
     echo "$release_defs" | grep $EPICS_MODULES_PATH
+
+    echo $EPICS_BASE_PATH
 }
 
 get_used_epics_modules() {

--- a/images/docker-compose-mca.yml
+++ b/images/docker-compose-mca.yml
@@ -8,6 +8,6 @@ services:
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
-        REPONAME: mca
+        APP_DIRS: /opt/epics/modules/mca
         RUNDIR: /opt/epics/modules/mca/iocBoot/iocAmptek
         RUNTIME_PACKAGES: libpcap0.8 libnet1 libusb-1.0-0

--- a/images/docker-compose-motorpigcs2.yml
+++ b/images/docker-compose-motorpigcs2.yml
@@ -8,5 +8,5 @@ services:
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
-        REPONAME: motorpigcs2
+        APP_DIRS: /opt/epics/modules/motor/modules/motorPIGCS2/iocs/pigcs2IOC
         RUNDIR: /opt/epics/modules/motor/modules/motorPIGCS2/iocs/pigcs2IOC/iocBoot/iocPIGCS2

--- a/images/docker-compose-opcua.yml
+++ b/images/docker-compose-opcua.yml
@@ -8,6 +8,6 @@ services:
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
-        REPONAME: opcua
+        APP_DIRS: /opt/epics/modules/opcua
         RUNDIR: /opt/epics/modules/opcua/iocBoot/iocUaDemoServer
         RUNTIME_PACKAGES: libxml2 libssl3

--- a/images/docker-compose-pvagw.yml
+++ b/images/docker-compose-pvagw.yml
@@ -8,5 +8,6 @@ services:
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
+        APP_DIRS: /opt/epics/modules/p4p
         RUNDIR: /opt/epics/modules/p4p/bin/linux-x86_64
         RUNTIME_PACKAGES: python3-numpy python3-ply

--- a/images/docker-compose-pvagw.yml
+++ b/images/docker-compose-pvagw.yml
@@ -10,4 +10,5 @@ services:
       args:
         APP_DIRS: /opt/epics/modules/p4p
         RUNDIR: /opt/epics/modules/p4p/bin/linux-x86_64
-        RUNTIME_PACKAGES: python3-numpy python3-ply
+        ENTRYPOINT: ./pvagw
+        RUNTIME_PACKAGES: python3-numpy python3-ply libevent-pthreads-2.1-7


### PR DESCRIPTION
Both `dynamic-link` and `no-build` targets generate unnecessarily large IOC images due to the trivial `COPY` done from `/opt`. Clean up everything from there and `/usr/local` directory before doing the `COPY` to the IOC image.

Clean up strategy proposed here is the following:

- Remove entirely any module that does not have a shared library linked against binaries under the IOC target directories (i.e. `/opt/$REPONAME` or `$RUNDIR`);
- Prune directories from used modules and EPICS base not containing shared libraries, EPICS databases or autosave requirement files;
- Remove any shared library not linked against binaries under IOC target directories;
- Remove all statically linked libraries;

For pruning module directories, another approach that could be followed is to delegate this responsibility to `install_module`. This way, we can have contextualized pruning for modules. On the other hand, this cannot be as aggressive as implemented in this proposal, as build-dependent files (the ones defining the build-system itself, for instance) must exist until the IOC build is complete.

I have tested this with [ad-aravis-epics-ioc](https://github.com/cnpem/ad-aravis-epics-ioc), and it shrinks the image size from 1.33GB down to 322MB.

This should be further tested and extensively reviewed, so that no artifact is removed unexpectedly.