### PR TITLE
images: add OPCUA image.

### DIFF
--- a/.github/workflows/included-images.yml
+++ b/.github/workflows/included-images.yml
@@ -1,0 +1,33 @@
+name: Build included image
+on:
+  workflow_run:
+    workflows: ["Base image build"]
+    tags:
+      - 'v*'
+    types:
+      - completed
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    env:
+      REGISTRY: ghcr.io/${{ github.repository_owner }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push tagged image
+        uses: docker/bake-action@v4
+        with:
+          workdir: images/
+          files: docker-compose-opcua.yml
+          push: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
+A new container image, `ghcr.io/cnpem/opcua-epics-ioc`, is now available.
+
 ### New features
 
 * base: add OPCUA and `ether_ip` IOCs and modules. by @guirodrigueslima in
   https://github.com/cnpem/epics-in-docker/pull/57
+* images: add OPCUA image. by @ericonr in
+  https://github.com/cnpem/epics-in-docker/pull/61
 
 ## v0.7.0
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ registry](https://github.com/cnpem/epics-in-docker/pkgs/container/lnls-debian-11
 
 The versions used in the base image are defined in `base/.env`.
 
+## Included IOC images
+
+Some IOC images are provided by this repository directly, and can be used
+without any build step.
+
+- OPCUA IOC: `ghcr.io/cnpem/opcua-epics-ioc`
+
 ## IOC images
 
 IOC repositories should include this repository as a submodule in their root,

--- a/images/docker-compose-opcua.yml
+++ b/images/docker-compose-opcua.yml
@@ -1,0 +1,13 @@
+services:
+  ioc:
+    image: ghcr.io/cnpem/opcua-epics-ioc
+    build:
+      context: ./
+      dockerfile: ../Dockerfile
+      target: no-build
+      labels:
+        org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
+      args:
+        REPONAME: opcua
+        RUNDIR: /opt/epics/modules/opcua/iocBoot/iocUaDemoServer
+        RUNTIME_PACKAGES: libxml2 libssl1.1


### PR DESCRIPTION
Since the OPCUA IOC we use is built alongside the OPCUA module, we can simply export the IOC image ourselves.

---

This is still missing automatic generation of the image in CI. Creating the tagged image is easy, we just need to [depend](https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions) on the workflow which pushes the base image. The hard part is running it for PRs as well... This means it probably has to be in the same workflow and must deal with the recently built base image which will have its own name but should be called `X.Y.Z-dev`.

I'm not sure how far we need to go before merging and tagging a release so it can be used.