### PR TITLE
ioc: configure static link directly on CONFIG_SITE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ FROM build-stage AS static-build
 ARG JOBS=1
 ARG RUNDIR
 
-RUN echo STATIC_BUILD=YES >> configure/CONFIG_SITE.local
+RUN echo STATIC_BUILD=YES >> configure/CONFIG_SITE
 
 RUN make distclean && make -j ${JOBS} && make clean && make -C ${RUNDIR}
 


### PR DESCRIPTION
Modern EPICS templates defines an optional include to a `.local` version of the configuration files. However, it is not guaranteed that this haven't been removed in the IOC, or that another template was used, which does not contain this logic. In such situations, compiling will succeed if we place STATIC_BUILD in the local file, but the IOC won't be statically linked, as the configuration won't ever be loaded.

Use CONFIG_SITE directly to avoid mistakenly compiling an application with dynamic linking when the used target is `static-link` and the template does not include local settings. This also lowers the knowledge required about the EPICS build system to successfully build the IOCs.

Note that appending to the end of CONFIG_SITE will correctly override any configuration in CONFIG_SITE.local if there is any.