### PR TITLE
base: remove CALC dependency on Sequencer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### New features
+
+* base: add IOCStats module. by @gustavosr8 in
+  https://github.com/cnpem/epics-in-docker/pull/62
+* base: add IPMIComm module. by @gustavosr8 in
+  https://github.com/cnpem/epics-in-docker/pull/62
+* base: add pyDevSup module. by @gustavosr8 in
+  https://github.com/cnpem/epics-in-docker/pull/62
+
+## v0.8.1
+
+OPCUA container image build with GitHub Actions has been fixed.
+
 ## v0.8.0
 
 A new container image, `ghcr.io/cnpem/opcua-epics-ioc`, is now available.
@@ -12,12 +25,6 @@ A new container image, `ghcr.io/cnpem/opcua-epics-ioc`, is now available.
   https://github.com/cnpem/epics-in-docker/pull/57
 * images: add OPCUA image. by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/61
-* base: add IOCStats module. by @gustavosr8 in
-  https://github.com/cnpem/epics-in-docker/pull/62
-* base: add IPMIComm module. by @gustavosr8 in
-  https://github.com/cnpem/epics-in-docker/pull/62
-* base: add pyDevSup module. by @gustavosr8 in
-  https://github.com/cnpem/epics-in-docker/pull/62
 
 ## v0.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking changes
+
+* base: remove CALC dependency on Sequencer. by @henriquesimoes in
+  https://github.com/cnpem/epics-in-docker/pull/68.
+
 ### New features
 
 * base: add IOCStats module. by @gustavosr8 in

--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -14,7 +14,6 @@ EPICS_BASE
 
 install_from_github epics-modules calc CALC $CALC_VERSION "
 EPICS_BASE
-SNCSEQ
 "
 
 # Build asyn without seq since it's only needed for testIPServer


### PR DESCRIPTION
By making Calc depend on Sequencer, all IOCs which directly or indirectly depend on Calc must explicitly link against Sequencer library when using static-link target. This means most previously dynamic-linked IOCs will not cleanly build without changes to src/Makefile when moving to epics-in-docker. In turn, we gain the [feature of editing sseq records at runtime][1], which is not used by IOCs we currently maintain and is probable not to be used by future ones.

Drop support for editSseq in favor of making it easier to containerize new IOCs.

This reverts commit https://github.com/cnpem/epics-in-docker/commit/a2096baee404ce724eb0cf91eda57d98fce059b7.

[1]: https://github.com/epics-modules/calc/blob/R3-7-5/calcApp/src/calcSupport_withSNCSEQ.dbd