### PR TITLE
Ensure single UID is used inside containers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Bug fixes
+
+* ioc: disable APT sandbox. by @henriquesimoes in
+  https://github.com/cnpem/epics-in-docker/69
+  * This allows to use APT in containers deployed in systems without subuid and
+    subgid.
+
 ### New features
 
 * base: update ipmiComm patch to install general templates. by

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG RUNTIME_PACKAGES
 ARG RUNTIME_TAR_PACKAGES
 ARG RUNTIME_PIP_PACKAGES
 
+COPY --from=build-image /etc/apt/apt.conf.d/90-disable-sandbox.conf /etc/apt/apt.conf.d/90-disable-sandbox.conf
+
 RUN apt update -y && \
     apt install -y --no-install-recommends \
         libreadline8 \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,10 @@ ARG JOBS
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Disable APT sandbox so that single UID restriction is satisfied in systems
+# without subuid and subgid configured.
+RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/90-disable-sandbox.conf
+
 RUN apt update -y && \
     apt install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
APT is one of the applications that assume multiple effective UIDs exist, so that it can sandbox itself. When running with `ignore_chown_errors` option enabled (see [podman(1)](https://manpages.debian.org/bookworm/podman/podman.1.en.html#Rootless_mode)), this will lead to `setgroups`, `seteuid` and `setguid` syscalls to fail, breaking most of `apt` commands.

Ensure that a single UID is used inside the containers, both at base build image (without `/etc/set{u,g}id` settings) and IOC runtime, especially allowing one to properly use apt.