### PR TITLE
base: use single job to build ipmiComm.

### DIFF
--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -72,7 +72,7 @@ EPICS_BASE
 
 download_from_github slac-epics-modules ipmiComm $IPMICOMM_VERSION
 patch -d ipmiComm -Np1 < ipmicomm.patch
-install_module ipmiComm IPMICOMM "
+JOBS=1 install_module ipmiComm IPMICOMM "
 EPICS_BASE
 ASYN
 "


### PR DESCRIPTION
Using with multiple processes breaks the build, as inter-dependencies are not properly handled when generating the substituted databases. Use a single process for this specific module, so that local builds of other modules can use multiple jobs without breaking.