### PR TITLE
ioc: install busybox symbolic links.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,9 @@ RUN apt update -y && \
         busybox \
         netcat-openbsd \
         procserv \
-        wget \
         $([ -n "$RUNTIME_PIP_PACKAGES" ] && echo pip) \
         $RUNTIME_PACKAGES && \
-    ln -s /bin/busybox /usr/bin/unzip && \
+    busybox --install && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Packages that strictly need to be installed via `pip` can be listed under the
 Packages essential to all (or most) IOCs should be added to
 [this repository's `Dockerfile`](./Dockerfile).
 
+Extra files can also be downloaded and installed by listing their TAR or ZIP
+archive URLs under `BUILD_TAR_PACKAGES` or `RUNTIME_TAR_PACKAGES`. To use HTTPS
+(or any other TLS-based protocol), `ca-certificates` must also be added to
+`RUNTIME_PACKAGES`.
+
 The template above assumes the containers will be uploaded to the GitHub
 registry.
 

--- a/base/lnls-get-n-unpack.sh
+++ b/base/lnls-get-n-unpack.sh
@@ -18,7 +18,7 @@ for url; do
     download_dir=$(mktemp -d)
 
     echo Downloading "$url"...
-    wget -P $download_dir -o /tmp/wget.log "$url" || (cat /tmp/wget.log && false)
+    wget -P $download_dir "$url" &> /tmp/wget.log || (cat /tmp/wget.log && false)
 
     filename=$(basename $download_dir/*)
 


### PR DESCRIPTION
Make all busybox goodies available in the PATH without having to worry about them being from busybox. This is done automatically for Alpine, but not for Debian.

This removes the need to install wget, since it is already provided by busybox. However, its version packaged by Debian does not implement `-o` flag, requiring us to use bash redirection instead.

Fixes: ffdbecc1 (ioc: initial commit.)