### PR TITLE
ioc: allow pip to install packages system-wide.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build-image /usr/local/bin/lnls-get-n-unpack /usr/local/bin/lnls-get
 RUN lnls-get-n-unpack -r $RUNTIME_TAR_PACKAGES && \
     ldconfig
 RUN if [ -n "$RUNTIME_PIP_PACKAGES" ]; then \
-        pip install $RUNTIME_PIP_PACKAGES; \
+        pip install --break-system-packages $RUNTIME_PIP_PACKAGES; \
     fi
 
 COPY --from=build-image /usr/local/bin/lnls-run /usr/local/bin/lnls-run


### PR DESCRIPTION
Since Debian 12, installing packages [outside a virtual environment is an error by default][1] as first specified by [PEP 668][2]. The rationale for forcing this is not applicable in our context, since the container image is dedicated to the IOC under construction, which renders it an isolated environment of its own.

Users should still provide RUNTIME_PIP_PACKAGES that are compatible with the system packages, not really breaking the system, similarly to what is done for shared libraries.

[1]: https://salsa.debian.org/python-team/packages/python-pip/-/commit/5aeba2464e36020a34e2bc074872771f5ef4973d
[2]: https://peps.python.org/pep-0668

Fixes: 39bb0d4e1d42 (base: update to Debian 12., 2024-10-31)