### PR TITLE
ci: allow release branch to be protected.

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Update release branch
         run: |
           git push origin ${{ github.ref_name }}:release


### PR DESCRIPTION
The deploy key can be added to the bypass list for branch protection, allowing the release branch to be protected from pushes from regular users.

Based on:
https://github.com/orgs/community/discussions/25305#discussioncomment-10728028