### PR TITLE
base: speed up local rebuilds.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,6 +5,8 @@ FROM debian:${DEBIAN_VERSION}
 ARG JOBS
 
 ENV DEBIAN_FRONTEND=noninteractive
+ARG CCACHE_DIR=/ccache
+ARG CCACHE_STATSLOG=/tmp/ccache.statslog
 
 # Disable APT sandbox so that single UID restriction is satisfied in systems
 # without subuid and subgid configured.
@@ -14,6 +16,7 @@ RUN apt update -y && \
     apt install -y --no-install-recommends \
         build-essential \
         cmake \
+        ccache \
         git \
         libaravis-dev \
         libboost-test-dev \
@@ -37,7 +40,8 @@ RUN apt update -y && \
         cython3 \
         python3-numpy \
         python3-setuptools \
-        ca-certificates
+        ca-certificates && \
+    for p in gcc g++; do ln -vs /usr/bin/ccache /usr/local/bin/$p; done
 
 COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
 
@@ -54,12 +58,12 @@ WORKDIR /opt/epics
 
 COPY epics-base-static-linking.patch $EPICS_IN_DOCKER
 COPY epics_versions.sh install_epics.sh $EPICS_IN_DOCKER
-RUN $EPICS_IN_DOCKER/install_epics.sh
+RUN --mount=type=cache,target=/ccache/ USE_CCACHE=1 $EPICS_IN_DOCKER/install_epics.sh
 
 WORKDIR ${EPICS_MODULES_PATH}
 
 COPY modules_versions.sh install_modules.sh $EPICS_IN_DOCKER
-RUN NEEDS_TIRPC=YES $EPICS_IN_DOCKER/install_modules.sh
+RUN --mount=type=cache,target=/ccache/ NEEDS_TIRPC=YES $EPICS_IN_DOCKER/install_modules.sh
 
 COPY cagateway_versions.sh install_cagateway.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_cagateway.sh
@@ -67,10 +71,13 @@ RUN $EPICS_IN_DOCKER/install_cagateway.sh
 COPY adeiger-remove-lz4.patch  $EPICS_IN_DOCKER
 COPY adeiger-stream2-ub.patch  $EPICS_IN_DOCKER
 COPY area_detector_versions.sh install_area_detector.sh $EPICS_IN_DOCKER
-RUN $EPICS_IN_DOCKER/install_area_detector.sh
+RUN --mount=type=cache,target=/ccache/ $EPICS_IN_DOCKER/install_area_detector.sh
 
 COPY motor_versions.sh install_motor.sh $EPICS_IN_DOCKER
-RUN $EPICS_IN_DOCKER/install_motor.sh
+RUN --mount=type=cache,target=/ccache/ $EPICS_IN_DOCKER/install_motor.sh
+
+RUN ccache --show-log-stats && \
+    for p in gcc g++; do ln -vsf /usr/bin/$p /usr/local/bin/$p; done
 
 COPY lnls-build-ioc.sh /usr/local/bin/lnls-build-ioc
 COPY lnls-prune-artifacts.sh /usr/local/bin/lnls-prune-artifacts

--- a/base/install_epics.sh
+++ b/base/install_epics.sh
@@ -16,4 +16,8 @@ if [ -n "$COMMANDLINE_LIBRARY" ]; then
     echo "COMMANDLINE_LIBRARY = $COMMANDLINE_LIBRARY" >> ${EPICS_BASE_PATH}/configure/CONFIG_SITE.local
 fi
 
+if [ "$USE_CCACHE" = 1 ]; then
+    printf "CC=/usr/local/bin/gcc\nCCC=/usr/local/bin/g++\n" >> ${EPICS_BASE_PATH}/configure/CONFIG.gnuCommon
+fi
+
 install_module base EPICS_BASE

--- a/base/musl/Dockerfile
+++ b/base/musl/Dockerfile
@@ -4,9 +4,13 @@ FROM alpine:$ALPINE_VERSION
 
 ARG JOBS
 
+ARG CCACHE_DIR=/ccache
+ARG CCACHE_STATSLOG=/tmp/ccache.statslog
+
 RUN apk add --no-cache \
     bash \
     cmake \
+    ccache \
     git \
     g++ \
     libevent-dev \
@@ -37,7 +41,8 @@ RUN apk add --no-cache \
     python3-dev \
     py3-setuptools \
     cython \
-    py3-numpy-dev
+    py3-numpy-dev && \
+    for p in gcc g++; do ln -vs /usr/bin/ccache /usr/local/bin/$p; done
 
 COPY lnls-get-n-unpack.sh /usr/local/bin/lnls-get-n-unpack
 COPY lnls-run.sh /usr/local/bin/lnls-run
@@ -55,11 +60,14 @@ WORKDIR /opt/epics
 
 COPY epics-base-static-linking.patch $EPICS_IN_DOCKER
 COPY epics_versions.sh install_epics.sh $EPICS_IN_DOCKER
-RUN COMMANDLINE_LIBRARY=READLINE_NCURSES $EPICS_IN_DOCKER/install_epics.sh
+RUN --mount=type=cache,target=/ccache/ USE_CCACHE=1 COMMANDLINE_LIBRARY=READLINE_NCURSES $EPICS_IN_DOCKER/install_epics.sh
 
 WORKDIR ${EPICS_MODULES_PATH}
 
 COPY modules_versions.sh install_modules.sh $EPICS_IN_DOCKER
-RUN NEEDS_TIRPC=YES $EPICS_IN_DOCKER/install_modules.sh
+RUN --mount=type=cache,target=/ccache/ NEEDS_TIRPC=YES $EPICS_IN_DOCKER/install_modules.sh
+
+RUN ccache --show-log-stats && \
+    for p in gcc g++; do ln -vsf /usr/bin/$p /usr/local/bin/$p; done
 
 COPY lnls-build-static-ioc.sh /usr/local/bin/lnls-build-static-ioc


### PR DESCRIPTION
Using ccache can speed up local rebuilds even when the container layer cache is invalidated, which is easy to happen. It also requires a less complicated and less fragile setup than distcc (though distcc will always make for faster first builds).

install_epics.sh still supports ccache-less setups, should that be required.

On my machine, building an image with ccache for the first time took ~15m. Rebuilding it after invalidating the layer cache took only 3m36s. The output of 'ccache -s' is reproduced below:

    Cacheable calls:   3858 / 8743 (44.13%)
      Hits:            1923 / 3858 (49.84%)
        Direct:        1822 / 1923 (94.75%)
        Preprocessed:   101 / 1923 ( 5.25%)
      Misses:          1935 / 3858 (50.16%)
    Uncacheable calls: 4885 / 8743 (55.87%)
    Local storage:
      Cache size (GB): 0.18 / 5.00 ( 3.70%)

It is not clear why the cache hits were below 50%, but it was still enough to make a big difference in build times.

This was based on StackOverflow [1].

[1] https://stackoverflow.com/a/56833198