### PR TITLE
base: don't use recsync/client for RECCASTER.

### DIFF
--- a/base/install_modules.sh
+++ b/base/install_modules.sh
@@ -57,7 +57,10 @@ SNCSEQ
 "
 
 download_from_github ChannelFinder recsync $RECCASTER_VERSION
-install_module recsync/client RECCASTER "
+mv recsync recsync-root
+mv recsync-root/client recsync
+rm -r recsync-root
+install_module recsync RECCASTER "
 EPICS_BASE
 "
 


### PR DESCRIPTION
Using a subdirectory of the tarball as the module's location means the tarball's root, recsync/, isn't included in the $EPICS_RELEASE_FILE and can't be used for image pruning steps. This means that, for IOCs which don't use reccaster, the recsync/ directory is still present in the final image; and even for those which use reccaster, the files in the directory haven't been pruned (though they only amount to 288K).

In order to guarantee that the recsync/ directory is always removed when unused, we extract the reccaster module from it, and remove all other files.

---

Fixes #102 