### PR TITLE
RELEASE: remove manual update of release branch.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,10 +46,6 @@ And its contents should be only the title: `vX.Y.Z`.
 For this step, it is necessary to [configure Git to sign tags with SSH
 keys](https://docs.gitlab.com/ee/user/project/repository/signed_commits/ssh.html).
 
-## `release` branch
-
-The `release` branch should be updated to point to the new tag.
-
 ## `main` branch
 
 A new commit should be created in the `main` branch, updating the version used


### PR DESCRIPTION
Updating the 'release' branch manually is no longer necessary after b1163e1 (ci: add workflow to update the release branch., 2024-11-08).