### PR TITLE
ioc: defer git directory removal until after build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,6 @@ WORKDIR /opt/${REPONAME}
 COPY . .
 
 RUN cp $EPICS_RELEASE_FILE configure/RELEASE
-RUN rm -rf .git/
 
 
 FROM build-stage AS dynamic-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ ARG RUNDIR
 ARG SKIP_TESTS
 ARG SKIP_PRUNE
 
-RUN make distclean && make -j ${JOBS} && make $([ "$SKIP_TESTS" != 1 ] && echo runtests) && make clean && make -C ${RUNDIR}
+RUN lnls-build-ioc
 
 RUN if [ "$SKIP_PRUNE" != 1 ]; then lnls-prune-artifacts ${APP_DIRS} ${PWD} ${RUNDIR}; fi
 
@@ -128,7 +128,7 @@ ARG SKIP_TESTS
 
 RUN echo STATIC_BUILD=YES >> configure/CONFIG_SITE
 
-RUN make distclean && make -j ${JOBS} && make $([ "$SKIP_TESTS" != 1 ] && echo runtests) && make clean && make -C ${RUNDIR}
+RUN lnls-build-ioc
 
 
 FROM base AS static-link

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -71,5 +71,6 @@ ARG DEBIAN_VERSION
 COPY opcua_versions.sh install_opcua.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_opcua.sh
 
+COPY lnls-build-ioc.sh /usr/local/bin/lnls-build-ioc
 COPY lnls-prune-artifacts.sh /usr/local/bin/lnls-prune-artifacts
 COPY lnls-run.sh /usr/local/bin/lnls-run

--- a/base/lnls-build-ioc.sh
+++ b/base/lnls-build-ioc.sh
@@ -12,3 +12,5 @@ fi
 make clean
 
 make -C ${RUNDIR}
+
+rm -rf .git/

--- a/base/lnls-build-ioc.sh
+++ b/base/lnls-build-ioc.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eux
+
+make distclean
+make -j ${JOBS}
+
+if [ "$SKIP_TESTS" != 1 ]; then
+  make runtests
+fi
+
+make clean
+
+make -C ${RUNDIR}


### PR DESCRIPTION
The .git directory is removed mainly for reducing the size of the resulting IOC image. However, doing this before compiling the IOC rules out the possibility of automatically detecting the version during the build (e.g. by calling `git describe` in the Makefile). Defer the removal to right after the IOC has been built, but still before it is COPY'ed to the final image, satisfying both goals.

The downside of this approach is the duplication in both dynamic and static build stages, which need to be kept in sync. Given that a similar issue already occurs for the build pipeline itself and that the benefits outweigh the drawbacks, it seems fine by now.