### PR TITLE
ioc: default SKIP_TESTS to false.

### DIFF
--- a/base/lnls-build-ioc.sh
+++ b/base/lnls-build-ioc.sh
@@ -5,7 +5,7 @@ set -eux
 make distclean
 make -j ${JOBS}
 
-if [ "$SKIP_TESTS" != 1 ]; then
+if [ "${SKIP_TESTS:-0}" != 1 ]; then
   make runtests
 fi
 


### PR DESCRIPTION
When the code was extracted to a standalone script in the fixed commit, undefined variables have been enforced not to exist by using the `-u` switch. However, SKIP_TESTS is thought to be optionally defined in the compose file (in order to make it more concise), which means it is often undefined. Give it the default value of false to make it optional again. Keep the setting of failing upon usage of undefined variables, as it is still beneficial in general.

Notice that no other variable needs a default value, as we enforced RUNDIR to be defined (because it is argument of a required option), and JOBS always had a default value.

Fixes: 1ed359f (ioc: deduplicate build steps in different targets., 2025-05-22)