### PR TITLE
images: add softIOC image

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -68,6 +68,7 @@ jobs:
             docker-compose-ca-gateway.yml
             docker-compose-pvagw.yml
             docker-compose-rgamv2.yml
+            docker-compose-softioc.yml
             docker-compose-twincat-ads.yml
           push: ${{ github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true' && github.ref_type == 'tag' }}
   pre_commit:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@ for that release.
   https://github.com/cnpem/epics-in-docker/pull/139
 * base: update motorPIGCS2 module to version R1-3. by @guirodrigueslima in
   https://github.com/cnpem/epics-in-docker/pull/138
+* images: add softIOC image. by @guirodrigueslima in
+  https://github.com/cnpem/epics-in-docker/pull/145
 
 ## v0.14.1
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ without any build step.
 | Motor PIGCS2 IOC | `ghcr.io/cnpem/motor-pigcs2-epics-ioc` | `PIGCS2` |
 | Motor Parker IOC | `ghcr.io/cnpem/motor-parker-epics-ioc` | `Parker` |
 | rgamv2 IOC       | `ghcr.io/cnpem/rgamv2-epics-ioc`       | `rgamv2` |
+| SoftIOC          | `ghcr.io/cnpem/softioc-epics-ioc`      | `softIOC`|
 | Twincat ADS IOC  | `ghcr.io/cnpem/twincat-ads-epics-ioc`  | `twincatADS` |
 
 The IOC binary can be found in `/opt/<IOC>/bin/linux-x86_64/<IOC>` and startup

--- a/images/docker-compose-softioc.yml
+++ b/images/docker-compose-softioc.yml
@@ -1,0 +1,23 @@
+services:
+  stream:
+    image: ghcr.io/cnpem/softioc-epics-ioc:$TAG
+    build:
+      context: ./
+      dockerfile: ../Dockerfile
+      target: dynamic-link
+      labels:
+        org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
+      args:
+        RUNTIME_PACKAGES: libpython3.11
+        RUNTIME_PIP_PACKAGES: numpy==1.24
+        IOC_CREATE: 1
+        REPONAME: softIOC
+        RUNDIR: /opt/softIOC/iocBoot/iocsoftIOC
+        IOC_DBDS:
+          pyDevSup.dbd
+          sscan.dbd
+          calc.dbd
+        IOC_LIBS:
+          sscan
+          calc
+          pyDevSup$(PY_LD_VER)


### PR DESCRIPTION
Add docker-compose-softioc.yml for running a softIOC, including EPICS Base, sscan, calc, and pyDevSup modules.

- [x] Create a compose file for the new IOC under the `images` directory;
- [x] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [x] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.