### PR TITLE
Install templates by default in lnls-create-ioc

### DIFF
--- a/base/lnls-create-ioc.sh
+++ b/base/lnls-create-ioc.sh
@@ -81,6 +81,12 @@ echo "TOP=../..
 include \${TOP}/configure/CONFIG
 " > "$MAKEFILE"
 
+echo "
+DB_INSTALLS += \${RECCASTER}/db/reccaster.db
+DB_INSTALLS += \${AUTOSAVE}/db/save_restoreStatus.db
+DB_INSTALLS += \${DEVIOCSTATS}/db/iocAdminSoft.db
+" >> "$MAKEFILE"
+
 if [ -n "${IOC_DBS:-}" ]; then
     for db in $IOC_DBS; do
         echo "DB_INSTALLS += $db" >> "$MAKEFILE"

--- a/base/lnls-create-ioc.sh
+++ b/base/lnls-create-ioc.sh
@@ -74,22 +74,22 @@ include \${TOP}/configure/RULES
 " >> "$MAKEFILE"
 
 # Modify database file in Db/Makefile
+MAKEFILE="${IOC_NAME}App/Db/Makefile"
+
+echo "TOP=../..
+
+include \${TOP}/configure/CONFIG
+" > "$MAKEFILE"
+
 if [ -n "${IOC_DBS:-}" ]; then
-    MAKEFILE="${IOC_NAME}App/Db/Makefile"
-
-    echo "TOP=../..
-
-    include \${TOP}/configure/CONFIG
-    " > "$MAKEFILE"
-
     for db in $IOC_DBS; do
         echo "DB_INSTALLS += $db" >> "$MAKEFILE"
     done
-
-    echo "
-    include \${TOP}/configure/RULES
-    " >> "$MAKEFILE"
 fi
+
+echo "
+include \${TOP}/configure/RULES
+" >> "$MAKEFILE"
 
 # Copy command file(s) or directory(ies)
 if [ -n "${IOC_CMDS:-}" ]; then


### PR DESCRIPTION
<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

# Description

[base: always write Db/Makefile in lnls-create-ioc](https://github.com/cnpem/epics-in-docker/commit/70afdcbe93395ab8bd8ffdf78e91ecc26b1c7696)

This will be used to install some templates into the created IOCs by
default.

# Checklist

- [X] Follow the commit format specified in `CONTRIBUTING.md`;
- [X] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.
- [X] Loading the records was tested with the rgamv2 image

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
