### PR TITLE
base: fix segfault in ADEiger

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -62,6 +62,7 @@ COPY cagateway_versions.sh install_cagateway.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_cagateway.sh
 
 COPY adeiger-remove-lz4.patch  $EPICS_IN_DOCKER
+COPY adeiger-stream2-ub.patch  $EPICS_IN_DOCKER
 COPY area_detector_versions.sh install_area_detector.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_area_detector.sh
 

--- a/base/adeiger-stream2-ub.patch
+++ b/base/adeiger-stream2-ub.patch
@@ -1,0 +1,51 @@
+From https://github.com/areaDetector/ADEiger/pull/93
+From 3ac2f780a2b26a43228682fa39fd92490789178c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=89rico=20Nogueira?= <erico.rolim@lnls.br>
+Date: Thu, 9 Apr 2026 21:08:50 -0300
+Subject: [PATCH] Fix Stream2 segfault
+
+We observed some non-deterministic crashes in the streamTask when using
+the Stream2 interface. We were able to capture a core dump, and it
+showed that the issue was in accessing 'mImageMsg->data.len'. This
+access happened before checking the message type, which meant that for
+'STREAM2_MSG_END' messages, it would trigger undefined behavior by
+accessing outside of the space allocated for s2msg.
+
+The fixed code only accesses the message through the mImageMsg pointer
+when it is of type 'STREAM2_MSG_IMAGE', and adds an additional
+sanity-check for any unexpected message types.
+---
+ eigerApp/src/stream2Api.cpp | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/eigerApp/src/stream2Api.cpp b/eigerApp/src/stream2Api.cpp
+index be10863..3c378ad 100644
+--- a/eigerApp/src/stream2Api.cpp
++++ b/eigerApp/src/stream2Api.cpp
+@@ -209,14 +209,20 @@ int Stream2API::waitFrame (int *end, int *numThresholds, int timeout)
+         fprintf(stderr, "error: error %i parsing message\n", err);
+         return err;
+     }
+-    mImageMsg = (stream2_image_msg *)s2msg;
+-    mNumThresholds = (int)mImageMsg->data.len;
+-    *numThresholds = mNumThresholds;
+ 
+-    if (mImageMsg->type == STREAM2_MSG_END)
+-    {
+-        *end = true;
++    switch (s2msg->type) {
++        case STREAM2_MSG_IMAGE:
++            mImageMsg = (stream2_image_msg *)s2msg;
++            mNumThresholds = (int)mImageMsg->data.len;
++            *numThresholds = mNumThresholds;
++            break;
++        case STREAM2_MSG_END:
++            *end = true;
++            break;
++        default:
++            err = STREAM_ERROR;
+     }
++
+     return err;
+ }
+ 

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -19,6 +19,7 @@ git submodule update --init --depth 1 -j ${JOBS} \
 
 download_from_github areaDetector ADEiger $ADEIGER_VERSION
 patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-remove-lz4.patch
+patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-stream2-ub.patch
 
 rm -rf .git
 


### PR DESCRIPTION
Import a patch from an unmerged PR [1].

[1] https://github.com/areaDetector/ADEiger/pull/93

---

I'm waiting on a review for #154 , so might as well try to bundle this in.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
