### PR TITLE
base: fix external trigger in ADEiger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug fixes
+
+* base: fix external trigger in ADEiger. by @ericonr in
+  https://github.com/cnpem/epics-in-docker/pull/158
+
 ## v0.15.0
 
 This releases adds multiple new IOC images to the project. External images for

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* base: fix external trigger in ADEiger. by @ericonr in
+  https://github.com/cnpem/epics-in-docker/pull/158
 * base: prune broken symbolic links correctly in
   https://github.com/cnpem/epics-in-docker/pull/173
   * Improve the shared library symbolic link removal to prevent the mistaken

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -70,6 +70,7 @@ RUN $EPICS_IN_DOCKER/install_cagateway.sh
 
 COPY adeiger-remove-lz4.patch  $EPICS_IN_DOCKER
 COPY adeiger-stream2-ub.patch  $EPICS_IN_DOCKER
+COPY adeiger-fix-tmexternal.patch  $EPICS_IN_DOCKER
 COPY area_detector_versions.sh install_area_detector.sh $EPICS_IN_DOCKER
 RUN --mount=type=cache,target=/ccache/ $EPICS_IN_DOCKER/install_area_detector.sh
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -63,6 +63,7 @@ RUN $EPICS_IN_DOCKER/install_cagateway.sh
 
 COPY adeiger-remove-lz4.patch  $EPICS_IN_DOCKER
 COPY adeiger-stream2-ub.patch  $EPICS_IN_DOCKER
+COPY adeiger-fix-tmexternal.patch  $EPICS_IN_DOCKER
 COPY area_detector_versions.sh install_area_detector.sh $EPICS_IN_DOCKER
 RUN $EPICS_IN_DOCKER/install_area_detector.sh
 

--- a/base/adeiger-fix-tmexternal.patch
+++ b/base/adeiger-fix-tmexternal.patch
@@ -1,0 +1,103 @@
+From https://github.com/areaDetector/ADEiger/pull/95
+diff --git a/eigerApp/src/eigerDetector.cpp b/eigerApp/src/eigerDetector.cpp
+index cf6e6ba..a7163d4 100644
+--- a/eigerApp/src/eigerDetector.cpp
++++ b/eigerApp/src/eigerDetector.cpp
+@@ -1011,26 +1011,25 @@ void eigerDetector::controlTask (void)
+                 getIntegerParam(ADStatus, &adStatus);
+             }
+         }
+-        else // TMExternalSeries or TMExternalEnable
++
++        // Wait for detector to stop acquiring.
++        // Essential for TMExternalSeries or TMExternalEnable,
++        // which have to wait for external action.
++        FLOW("waiting for detector state");
++        string state;
++        for(;;)
+         {
+-            // The Eiger does not indicate when acquisition is complete.
+-            // Wait either until the NumImagesCounter is the expected value or
+-            // until there is a manual stop event.
+-            int expectedImages = numImages * numTriggers;
+-            int numImagesCounter;
+-            for(;;)
+-            {
+-                getIntegerParam(ADNumImagesCounter, &numImagesCounter);
+-                if (numImagesCounter >= expectedImages) break;
+-                if (mStopEvent.tryWait()) break;
+-                unlock();
+-                epicsThreadSleep(0.1);
+-                lock();
+-            }
++            mState->fetch(state);
++            callParamCallbacks();
++            // We must exit this loop without the lock
++            unlock();
++            if (state != "configure" && state != "ready" && state != "acquire") break;
++            if (mStopEvent.wait(0.1)) break;
++            // If we haven't exited yet, grab the lock so we can update the param library
++            lock();
+         }
+ 
+         // All triggers issued, disarm the detector
+-        unlock();
+         status = mApi.disarm();
+         lock();
+ 
+@@ -1045,11 +1044,17 @@ void eigerDetector::controlTask (void)
+         {
+             // Wait FileWriter to go out of the "acquire" state
+             FLOW("waiting for FileWriter");
+-            string fwAcquire;
+-            do
++
++            for(;;)
+             {
+-                mFWState->get(fwAcquire);
+-            }while(fwAcquire == "acquire");
++                string fwAcquire;
++                lock();
++                mFWState->fetch(fwAcquire);
++                callParamCallbacks();
++                unlock();
++                if (fwAcquire != "acquire") break;
++                epicsThreadSleep(0.1);
++            }
+             epicsThreadSleep(0.5);
+ 
+             // Request polling task to stop
+@@ -1195,8 +1200,6 @@ void eigerDetector::downloadTask (void)
+ 
+         FLOW_ARGS("file=%s", file->name);
+ 
+-        file->refCount = file->parse + file->save;
+-
+         // Download the file
+         if(mApi.getFile(file->name, &file->data, &file->len))
+         {
+diff --git a/eigerApp/src/eigerDetector.h b/eigerApp/src/eigerDetector.h
+index 551c1e9..8831485 100644
+--- a/eigerApp/src/eigerDetector.h
++++ b/eigerApp/src/eigerDetector.h
+@@ -1,6 +1,7 @@
+ #ifndef EIGER_DETECTOR_H
+ #define EIGER_DETECTOR_H
+ 
++#include <atomic>
+ #include <map>
+ #include <vector>
+ 
+@@ -269,7 +270,11 @@ class eigerDetector : public ADDriver
+             mPollDoneEvent, mRestartEvent, mInitializeEvent;
+     epicsMessageQueue mPollQueue, mDownloadQueue, mParseQueue, mSaveQueue,
+             mReapQueue;
+-    bool mPollStop, mPollComplete, mStreamComplete;
++    std::atomic<bool> mPollStop;
++    // Access to this variable is synchronized by mPollQueue and mPollDoneEvent
++    bool mPollComplete;
++    // Access to this variable is synchronized by mStreamEvent and mStreamDoneEvent
++    bool mStreamComplete;
+     unsigned int mFrameNumber;
+     uid_t mFsUid, mFsGid;
+     EigerParamSet mParams;

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -20,6 +20,7 @@ git submodule update --init --depth 1 -j ${JOBS} \
 download_from_github areaDetector ADEiger $ADEIGER_VERSION $ADEIGER_SHA256
 patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-remove-lz4.patch
 patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-stream2-ub.patch
+patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-fix-tmexternal.patch
 
 rm -rf .git
 

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -20,6 +20,7 @@ git submodule update --init --depth 1 -j ${JOBS} \
 download_from_github areaDetector ADEiger $ADEIGER_VERSION
 patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-remove-lz4.patch
 patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-stream2-ub.patch
+patch -d ADEiger -Np1 < ${EPICS_IN_DOCKER}/adeiger-fix-tmexternal.patch
 
 rm -rf .git
 


### PR DESCRIPTION
This fix is relevant to our operation and is pulled from an unmerged PR.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [X] Follow the commit format specified in `CONTRIBUTING.md`;
- [X] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
