### PR TITLE
base: fix tarball naming for GitHub tags

### DIFF
--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -24,8 +24,8 @@ download_from_github() {
         rmdir $module_name
     fi
 
-    # GitHub tarballs for tags starting with 'v' don't include that 'v'
-    commit=${commit#v}
+    # GitHub tarballs for tags starting with 'v' or 'V' don't include those characters
+    commit=${commit#[vV]}
     mv $module_name-$commit $module_name
 }
 


### PR DESCRIPTION
Adjusted tarball naming to account for GitHub tags starting with "v" or "V", since this prefix is not included in the generated archive filename.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
