### PR TITLE
base: enable build with Boost.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,6 +16,8 @@ RUN apt update -y && \
         cmake \
         git \
         libaravis-dev \
+        libboost-test-dev \
+        libboost-system-dev \
         libevent-dev \
         libnet-dev \
         libpcap-dev \

--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -53,7 +53,8 @@ ln -s RELEASE.local RELEASE_LIBS.local
 echo "
 BUILD_IOCS=NO
 
-WITH_BOOST=NO
+WITH_BOOST=YES
+BOOST_EXTERNAL=YES
 
 WITH_PVA=YES
 WITH_QSRV=YES
@@ -106,6 +107,8 @@ cd -
 
 make -j${JOBS}
 make clean
+
+ADCore/bin/*/plugin-test
 
 cd ..
 


### PR DESCRIPTION
The areaDetector plugin-test utility uses the Boost Unit Testing Framework. To correctly build the application, we need to install the lib and enable its setting `WITH_BOOST` and `BOOST_EXTERNAL`

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [X] Follow the commit format specified in `CONTRIBUTING.md`;
- [x] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
