### PR TITLE
base: run plugin-test from /tmp.

### DIFF
--- a/base/install_area_detector.sh
+++ b/base/install_area_detector.sh
@@ -108,7 +108,11 @@ cd -
 make -j${JOBS}
 make clean
 
-ADCore/bin/*/plugin-test
+(
+    cd $(mktemp -d)
+    ${EPICS_MODULES_PATH}/areaDetector/ADCore/bin/*/plugin-test
+    rm -rf $PWD
+)
 
 cd ..
 


### PR DESCRIPTION
The plugin-test utility generates some xml and HDF5 files when performing the tests. When executed from areaDetector root directory, those files weren't reached by lnls-prune-artifacts and increases the final image in ~6MB. Run the tests from /tmp so the temporary artifacts are excluded when became useless.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`;

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
