### PR TITLE
base: prune broken symbolic links correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 ### Bug fixes
 
+* base: prune broken symbolic links correctly in
+  https://github.com/cnpem/epics-in-docker/pull/174
+  * Improve the shared library symbolic link removal to prevent the mistaken
+    pruning of linked libraries when there are hard-copies of shared objects
+    instead of proper symlinks.
 * Rectify pyDevSup IOC dependencies by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/165
   * Refer to the README for updated guidance on pyDevSup IOCs.

--- a/base/lnls-prune-artifacts.sh
+++ b/base/lnls-prune-artifacts.sh
@@ -204,13 +204,24 @@ remove_unused_shared_libraries() {
         if find $keep_paths -path "$lib" -exec false {} + 2> /dev/null; then
             echo "Removing shared library '$lib' ($size)..."
 
-            rm -f ${lib%.so*}.so*
+            rm -f "$lib"
         else
             echo "Keeping shared library '$lib' ($size)..."
         fi
     done
 }
 
+remove_broken_symlinks() {
+    # Depend on the GNU-specific implementation of find(1) to follow the link
+    # before the existence check
+    while read -r link; do
+        echo "Removing broken symlink '$link'..."
+
+        unlink "$link"
+    done < <(find $@ -xtype l)
+}
+
 clean_up_epics_modules $@
 remove_static_libraries /opt /usr/local
 remove_unused_shared_libraries $@
+remove_broken_symlinks /opt /usr/local


### PR DESCRIPTION
Shared libraries may be installed with symbolic links for their version components, so that build systems can pull the library based on their requirements on the API. During the prune phase, lnls-prune-artifacts will get rid of the main shared library as well as its corresponding links whenever the library isn't used, so the filesystem is consistent afterward.

That works as expected whenever the user application doesn't link to the library at all or links to the library using a proper symbolic link for *.so file. When the project ships the unversioned library as a hard copy, and such library is used by an application, an unwanted scenario is reached: remove_unused_shared_libraries() will decide to remove the *.so copy (because it is an ELF binary, but isn't used at runtime, as only its versioned copy is) and, thus, it will remove it along with its versioned friend; although the versioned one is to be kept.

Instead of relying on this fragile heuristics of removing every library with its corresponding link, which depends on the project build system to install symbolic links for versioned libraries, only remove the files checked against the "keep_paths". This ensures we won't ever remove a shared library in use. Still, to keep the filesystem consistent, introduce another short pruning step, which targets at finding only leftover broken links.

Broken links are queried using a GNU-specific flag (-xtype) for find(1), so that we check the existence of the linked file, not the link itself [1]. This is not a problem because pruning is relevant only for Debian-based build images, in which GNU tooling is available. Placing the documentation comment close to the find(1) would be possible with a here-string, but it would introduce a final newline [2], which would require us to treat empty values in the loop. As it is a short loop body, just use a process substitution instead.

Also, loop with a while-read pattern, so that we properly deal with files with spaces in their path.

[1] https://unix.stackexchange.com/a/38691
[2] https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Here-Strings

Fixes: 22ac3c6 (ioc: prune shared libraries from non-static builds., 2024-04-11)

---

This should fix the build issue affecting #173.

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`;
- [x] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.