### PR TITLE
base: add areaDetector CONFIG_SITE to generate areaDetector IOC

### DIFF
--- a/base/lnls-create-ioc.sh
+++ b/base/lnls-create-ioc.sh
@@ -97,6 +97,12 @@ echo "
 include \${TOP}/configure/RULES
 " >> "$MAKEFILE"
 
+CONFIG_SITE="configure/CONFIG_SITE"
+# Include areaDetector CONFIG_SITE in configure/CONFIG_SITE for IOC areaDetector.
+if [ "${IS_IOC_AREADETECTOR:-false}" = "true" ]; then
+    echo "include \$(AREA_DETECTOR)/configure/CONFIG_SITE" >> "$CONFIG_SITE"
+fi
+
 # Copy command file(s) or directory(ies)
 if [ -n "${IOC_CMDS:-}" ]; then
     for cmd in $IOC_CMDS; do

--- a/base/lnls-create-ioc.sh
+++ b/base/lnls-create-ioc.sh
@@ -18,8 +18,14 @@ INITIAL_FILES=$(ls -A)
 ${EPICS_BASE_PATH}/bin/linux-x86_64/makeBaseApp.pl -t ioc -p ${IOC_NAME} -u root ${IOC_NAME}
 ${EPICS_BASE_PATH}/bin/linux-x86_64/makeBaseApp.pl -i -t ioc -p ${IOC_NAME} -u root ${IOC_NAME}
 
+# Checks whether the IOC_NAME variable ends with App.
+IOC_APPDIR="$IOC_NAME"
+if [ "${IOC_NAME%App}" = "$IOC_NAME" ]; then
+    IOC_APPDIR="${IOC_NAME}App"
+fi
+
 # Modify src/Makefile with database and libraries dependency.
-MAKEFILE="${IOC_NAME}App/src/Makefile"
+MAKEFILE="${IOC_APPDIR}/src/Makefile"
 
 echo "TOP=../..
 
@@ -60,7 +66,7 @@ done
 
 echo "
 \${PROD_NAME}_SRCS += \${PROD_NAME}_registerRecordDeviceDriver.cpp
-\${PROD_NAME}_SRCS_DEFAULT += \${PROD_NAME}Main.cpp
+\${PROD_NAME}_SRCS_DEFAULT += ${IOC_NAME%App}Main.cpp
 " >> "$MAKEFILE"
 
 if [ "${IS_IOC_AREADETECTOR:-false}" = "true" ]; then
@@ -74,7 +80,7 @@ include \${TOP}/configure/RULES
 " >> "$MAKEFILE"
 
 # Modify database file in Db/Makefile
-MAKEFILE="${IOC_NAME}App/Db/Makefile"
+MAKEFILE="${IOC_APPDIR}/Db/Makefile"
 
 echo "TOP=../..
 
@@ -97,8 +103,10 @@ echo "
 include \${TOP}/configure/RULES
 " >> "$MAKEFILE"
 
+# Modify configure/CONFIG_SITE
 CONFIG_SITE="configure/CONFIG_SITE"
-# Include areaDetector CONFIG_SITE in configure/CONFIG_SITE for IOC areaDetector.
+
+# Include areaDetector CONFIG_SITE
 if [ "${IS_IOC_AREADETECTOR:-false}" = "true" ]; then
     echo "include \$(AREA_DETECTOR)/configure/CONFIG_SITE" >> "$CONFIG_SITE"
 fi


### PR DESCRIPTION
Automatically include AreaDetector's CONFIG_SITE in the configure/CONFIG_SITE file generated when creating areaDetector IOC. This provides the build configuration required for areaDetector.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
