### PR TITLE
ci: fix update release workflow

### DIFF
--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -17,4 +17,4 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Update release branch
         run: |
-          git push origin ${{ github.ref_name }}:release
+          git push origin ${{ github.sha }}:release


### PR DESCRIPTION
GitHub doesn't seem to accept pushing with the ref_name anymore. The commit SHA works just as well, so we can simply use it.

Fixes #179 