### PR TITLE
base: change IS_IOC_AREADETECTOR flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
   https://github.com/cnpem/epics-in-docker/pull/186
   * Fix IOC crash caused by connection problems.
 
+### Breaking changes
+
+* base: take only numeric values for IS_IOC_AREADETECTOR. by @guirodrigueslima in
+  https://github.com/cnpem/epics-in-docker/pull/184
+
 ## v0.16.0
 
 This update is recommended for most users. It greatly improves iocsh

--- a/base/lnls-create-ioc.sh
+++ b/base/lnls-create-ioc.sh
@@ -69,7 +69,7 @@ echo "
 \${PROD_NAME}_SRCS_DEFAULT += ${IOC_NAME%App}Main.cpp
 " >> "$MAKEFILE"
 
-if [ "${IS_IOC_AREADETECTOR:-false}" = "true" ]; then
+if [ "${IS_IOC_AREADETECTOR:-0}" -eq 1 ]; then
     echo "include \${ADCORE}/ADApp/commonDriverMakefile" >> "$MAKEFILE"
 fi
 
@@ -107,7 +107,7 @@ include \${TOP}/configure/RULES
 CONFIG_SITE="configure/CONFIG_SITE"
 
 # Include areaDetector CONFIG_SITE
-if [ "${IS_IOC_AREADETECTOR:-false}" = "true" ]; then
+if [ "${IS_IOC_AREADETECTOR:-0}" -eq 1 ]; then
     echo "include \$(AREA_DETECTOR)/configure/CONFIG_SITE" >> "$CONFIG_SITE"
 fi
 

--- a/images/docker-compose-ad-xspress3.yml
+++ b/images/docker-compose-ad-xspress3.yml
@@ -12,7 +12,7 @@ services:
         IOC_CREATE: 1
         REPONAME: xspress3App
         RUNDIR: /opt/xspress3App/iocBoot/iocxspress3App
-        IS_IOC_AREADETECTOR: true
+        IS_IOC_AREADETECTOR: 1
         IOC_DBDS:
           asyn.dbd
           xspress3Support.dbd


### PR DESCRIPTION
Changes the IS_IOC_AREADETECTOR flag, used when building AreaDetector IOCs, to accept numeric values (0 or 1) instead of strings (false or true).

This change is intended to standardize the project, since the other binary flags also use numeric values.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`;
- [x] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
