### PR TITLE
base: change symetrie path name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   https://github.com/cnpem/epics-in-docker/pull/191
   *  python3-numpy doesn't install libpython3.13 as expected. Install it
      manually.
+* base: fix symetrie path variable. by @guirodrigueslima in
+  https://github.com/cnpem/epics-in-docker/pull/185
+  * This meant the provided substitutions file wasn't working correctly.
 
 ## v0.16.0
 

--- a/base/install_motor.sh
+++ b/base/install_motor.sh
@@ -86,7 +86,7 @@ AUTOSAVE
 BUSY
 "
 
-install_from_github epics-motor motorSymetrie MOTOR_SYMETRIE $SYMETRIE_VERSION $SYMETRIE_SHA256 "
+install_from_github epics-motor motorSymetrie SYMETRIE $SYMETRIE_VERSION $SYMETRIE_SHA256 "
 EPICS_BASE
 ASYN
 MOTOR

--- a/images/docker-compose-motorsymetrie.yml
+++ b/images/docker-compose-motorsymetrie.yml
@@ -31,8 +31,8 @@ services:
           calc
           asyn
         IOC_DBS:
-          $(MOTOR_SYMETRIE)/db/SymetriePmac.template
-          $(MOTOR_SYMETRIE)/db/SymetriePmacAxis.template
-          $(MOTOR_SYMETRIE)/db/SymetriePmacError.template
-          $(MOTOR_SYMETRIE)/db/SymetriePmac.substitutions
+          $(SYMETRIE)/db/SymetriePmac.template
+          $(SYMETRIE)/db/SymetriePmacAxis.template
+          $(SYMETRIE)/db/SymetriePmacError.template
+          $(SYMETRIE)/db/SymetriePmac.substitutions
           $(MOTOR)/db/asyn_motor.db


### PR DESCRIPTION
The module path name was changed because the substitution file uses the name SYMETRIE by default.

https://github.com/epics-motor/motorSymetrie/blob/main/SYMETRIE_EPICSApp/Db/SymetriePmac.substitutions

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`;
- [x] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
