### PR TITLE
Correctly set the CLI tools for non 'end-user' usage

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -82,6 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install packages
-        run: sudo apt update -y && sudo apt install -y pre-commit shfmt
+        run: sudo apt-get update -y && sudo apt-get install -y pre-commit shfmt
       - name: Check pre-commit hooks
         run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG RUNTIME_PIP_PACKAGES
 
 ARG PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV PATH=$PATH
+ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL br.lnls.epics-in-docker.version="v0.16.0-dev"
 LABEL br.lnls.epics-in-docker.debian.version=${DEBIAN_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ LABEL br.lnls.procserv.supported-features.oneshot="true"
 
 COPY --from=build-image /etc/apt/apt.conf.d/90-disable-sandbox.conf /etc/apt/apt.conf.d/90-disable-sandbox.conf
 
-RUN apt update -y && \
-    apt install -y --no-install-recommends \
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
         libevent-pthreads-2.1-7 \
         libreadline8 \
         libtirpc3 \
@@ -33,7 +33,7 @@ RUN apt update -y && \
         $([ -n "$RUNTIME_PIP_PACKAGES" ] && echo pip) \
         $RUNTIME_PACKAGES && \
     busybox --install && \
-    apt clean && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build-image /usr/local/lib /usr/local/lib
@@ -83,8 +83,8 @@ ARG BUILD_PACKAGES
 ARG BUILD_TAR_PACKAGES
 
 RUN if [ -n "$BUILD_PACKAGES" ]; then \
-        apt update && \
-        apt install -y --no-install-recommends $BUILD_PACKAGES; \
+        apt-get update && \
+        apt-get install -y --no-install-recommends $BUILD_PACKAGES; \
     fi
 RUN lnls-get-n-unpack -r $BUILD_TAR_PACKAGES
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,8 +12,8 @@ ARG CCACHE_STATSLOG=/tmp/ccache.statslog
 # without subuid and subgid configured.
 RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/90-disable-sandbox.conf
 
-RUN apt update -y && \
-    apt install -y --no-install-recommends \
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
         build-essential \
         cmake \
         ccache \


### PR DESCRIPTION
By default, debconf(1) frontend is defined as 'dialog', which is incompatible with containerization interactions, leading to a series of failures and fallbacks to different frontend modes till it reaches 'noninteractive'.

This can be avoided by defining `DEBIAN_FRONTEND=noninteractive`.

Also, as defined in the CLI man page, `apt` is designed as an end-user tool, and scripts should use `apt-get` instead.

In practice, get rid of the warnings:

```
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8, <STDIN> line 16.)
debconf: falling back to frontend: Teletype
debconf: unable to initialize frontend: Teletype
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Noninteractive
```

and

`WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`