### PR TITLE
Module support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 * base: get all module paths. by @guirodrigueslima in
   https://github.com/cnpem/epics-in-docker/pull/188
+* base: add support for module builds. by @guirodrigueslima in
+  https://github.com/cnpem/epics-in-docker/pull/188
 
 ## v0.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 * base: update twincat-ads to v2.2.1 by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/186
   * Fix IOC crash caused by connection problems.
+  
+### New features
+
+* base: get all module paths. by @guirodrigueslima in
+  https://github.com/cnpem/epics-in-docker/pull/188
 
 ## v0.16.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ WORKDIR /opt/${REPONAME}
 
 COPY . .
 
+ARG IS_MODULE
+ARG MODULE_NAME
 ARG IOC_CREATE
 ARG IOC_LIBS
 ARG IOC_DBDS
@@ -98,7 +100,9 @@ ARG IOC_DBS
 ARG IOC_CMDS
 ARG IS_IOC_AREADETECTOR
 
-RUN if [ "$IOC_CREATE" = 1 ]; then lnls-create-ioc; fi
+RUN if [ "$IS_MODULE" = 1 ]; then lnls-build-module; fi
+
+RUN if [ "$IS_MODULE" = 1 ] || [ "$IOC_CREATE" = 1 ]; then lnls-create-ioc; fi
 
 RUN cp $EPICS_RELEASE_FILE configure/RELEASE
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -85,3 +85,4 @@ COPY lnls-build-ioc.sh /usr/local/bin/lnls-build-ioc
 COPY lnls-prune-artifacts.sh /usr/local/bin/lnls-prune-artifacts
 COPY lnls-run.sh /usr/local/bin/lnls-run
 COPY lnls-create-ioc.sh /usr/local/bin/lnls-create-ioc
+COPY lnls-build-module.sh /usr/local/bin/lnls-build-module

--- a/base/install-functions.sh
+++ b/base/install-functions.sh
@@ -4,6 +4,11 @@ if [ "$JOBS" -eq "-1" ]; then
 fi
 
 get_module_path() {
+    if [ "$1" = "*" ]; then
+        cat "$EPICS_RELEASE_FILE"
+        return
+    fi
+
     for module in $@; do
         if [ -n "$module" ]; then
             grep -E "^$module=" $EPICS_RELEASE_FILE

--- a/base/lnls-build-module.sh
+++ b/base/lnls-build-module.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+. $EPICS_IN_DOCKER/install-functions.sh
+
+mkdir -p ${EPICS_MODULES_PATH}/${REPONAME}
+mv * ${EPICS_MODULES_PATH}/${REPONAME}
+install_module ${EPICS_MODULES_PATH}/${REPONAME} ${MODULE_NAME} "*"


### PR DESCRIPTION
Hello everyone!

Attached is the implementation of the new method for building modules with epics-in-docker.

With this implementation, it will be possible to build a module from an epics-in-docker clone within the project itself and then create an IOC using that module.

To enable this behavior, simply set the IS_MODULE variable in the YAML file.

Below is an example of the YAML configuration I am using to build the ADGStreamer module:

```
services:
  ioc:
    image: ghcr.io/cnpem/adgstreamer
    build:
      context: ./
      dockerfile: docker/Dockerfile
      target: dynamic-link
      labels:
        org.opencontainers.image.source: https://github.com/cnpem/ADGStreamer
      args:
        BUILD_PACKAGES: libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
        RUNTIME_PACKAGES: libxml2 libtiff6 gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav
        IS_MODULE: 1
        MODULE_NAME: ADGST
        REPONAME: ADGStreamer
        RUNDIR: /opt/ADGStreamer/iocBoot/iocADGStreamer
        IS_IOC_AREADETECTOR: 1
        IOC_DBDS:
          asyn.dbd
          ADGStreamer.dbd
        IOC_LIBS:
          ADGStreamer
          asyn
        IOC_DBS:
          $(ADGST)/db/ADGStreamer.template
```

I would appreciate your help in defining a documentation structure for this new feature in the README.

With this change, epics-in-docker will support both IOC builds and module builds directly from an epics-in-docker clone within the project.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [x] Follow the commit format specified in `CONTRIBUTING.md`;
- [x] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
