### PR TITLE
Partially revert "Rectify pyDevSup IOC dependencies".

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 * base: update twincat-ads to v2.2.1 by @ericonr in
   https://github.com/cnpem/epics-in-docker/pull/186
   * Fix IOC crash caused by connection problems.
+* Partially revert "Rectify pyDevSup IOC dependencies" by @gustavosr8 in
+  https://github.com/cnpem/epics-in-docker/pull/191
+  *  python3-numpy doesn't install libpython3.13 as expected. Install it
+     manually.
 
 ## v0.16.0
 

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ not built in `ADSupport`.
 
 ### pyDevSup IOCs
 
-`pyDevSup` IOCs must include `python3-numpy` in the `RUNTIME_PACKAGES`. If the
-IOC includes Python extensions, it is also necessary to add `libpython3-dev` to
-the `BUILD_PACKAGES`.
+`pyDevSup` IOCs must include `libpython3.13` and `python3-numpy` in the
+`RUNTIME_PACKAGES`. If the IOC includes Python extensions, it is also necessary
+to add `libpython3-dev` to the `BUILD_PACKAGES`.
 
 ### Possible issues
 

--- a/images/docker-compose-softioc.yml
+++ b/images/docker-compose-softioc.yml
@@ -8,7 +8,7 @@ services:
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
-        RUNTIME_PACKAGES: python3-numpy
+        RUNTIME_PACKAGES: libpython3.13 python3-numpy
         IOC_CREATE: 1
         REPONAME: softIOC
         RUNDIR: /opt/softIOC/iocBoot/iocsoftIOC


### PR DESCRIPTION
This partially reverts commit 49386c978c2ea0651019d77b7838cbb609d63a24. python3-numpy doesn't install python3-dev, which keeps libpython3-13, as expected. It actually just list the package as a suggestion.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
