### PR TITLE
images: static link industry-pack IOC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,13 @@
   https://github.com/cnpem/epics-in-docker/pull/185
   * This meant the provided substitutions file wasn't working correctly.
 
+### Breaking changes
+
+* images: static link industry-pack IOC by @ericonr in
+  https://github.com/cnpem/epics-in-docker/pull/192
+  * Database and protocol files which were being pulled from `$(IP)` should now
+    be pulled from `$(TOP)`.
+
 ## v0.16.0
 
 This update is recommended for most users. It greatly improves iocsh

--- a/images/docker-compose-industry-pack.yml
+++ b/images/docker-compose-industry-pack.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./
       dockerfile: ../Dockerfile
-      target: dynamic-link
+      target: static-link
       labels:
         org.opencontainers.image.source: https://github.com/cnpem/epics-in-docker
       args:
@@ -27,3 +27,5 @@ services:
           calc
           seq pv
           stream
+        IOC_DBS:
+          $(wildcard $(IP)/db/*)


### PR DESCRIPTION
This can be done without greatly impacting users by installing all databases and protocols into the static image using a wildcard. If desired, we can later also add autosave req files and iocsh snippets.

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
