### PR TITLE
base: fix undefined variable error in lnls-build-static-ioc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
 * base: fix symetrie path variable. by @guirodrigueslima in
   https://github.com/cnpem/epics-in-docker/pull/185
   * This meant the provided substitutions file wasn't working correctly.
+* base: fix undefined variable error in lnls-build-static-ioc by @ericonr in
+  https://github.com/cnpem/epics-in-docker/pull/193
+  * `SKIP_TESTS` can now be unset.
 
 ### Breaking changes
 

--- a/base/lnls-build-static-ioc.sh
+++ b/base/lnls-build-static-ioc.sh
@@ -42,7 +42,7 @@ make_skip() {
 make_skip distclean
 make -j$(nproc)
 
-if [ "$SKIP_TESTS" != 1 ]; then
+if [ "${SKIP_TESTS:-}" != 1 ]; then
     make runtests
 fi
 


### PR DESCRIPTION
Fixes: 8ba1cc4 (ioc: run available IOC tests when building them., 2024-12-03)

<!--
Uncomment relevant sections and delete sections which are not applicable.
Please, follow the `CONTRIBUTING.md` Guidelines before submitting your contribution.
-->

<!--
# Description

Include a summary of the changes, with its context and relevant motivations.
-->

# Checklist

- [ ] Follow the commit format specified in `CONTRIBUTING.md`;
- [ ] Describe your user-facing changes in `CHANGES.md`, following the format
      established by previous entries.

<!--
## If adding a new IOC image

- [ ] Create a compose file for the new IOC under the `images` directory;
- [ ] List the new compose file in `.github/workflows/base-image.yml` under the
      `files` key in the `Build and push included IOC images` step;
- [ ] Add an entry in `README.md`, under `Included IOC images`, with the IOC
      name and its fully qualified container image name.
-->
